### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: cpp
+sudo: true
+
+os:
+- linux
+#- osx
+
+
+compiler: 
+- clang++
+#- gcc
+#- g++
+
+addons:
+ apt:
+  sources:
+  - boost-latest
+  packages:
+   - cmake
+   - libboost-all-dev
+   - libopencv-dev
+
+before_install:
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; if ! [[ `brew ls --versions boost` ]]; then brew install boost; fi; fi
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then if ! [[ `brew ls --versions gcc` ]]; then brew install gcc; fi; fi
+ - gcc --version
+ - g++ --version
+ - clang --version
+ - clang++ --version
+
+script:
+- mkdir -p build
+- cd build
+- cmake -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_VERBOSE_MAKEFILE=ON ..
+- make -j2
+- ./lib/tests
+  #- ./app/mousetrack

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mousetrack
 
+[![Build Status](https://travis-ci.org/Fluci/mousetrack.svg?branch=master)](https://travis-ci.org/Fluci/mousetrack)
+
 This project will be awesome!
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If operations run slow, you can try reinstalling OpenCV with these additional de
 
 ## Build project
 
-TL;RD: `$ mkdir build && cd build && cmake .. & make -j7`
+TL;DR: `$ mkdir build && cd build && cmake .. & make -j7`
 
 We use CMake as main building tool. CMake uses one or more input files (called `CMakeLists.txt`), to understand how to compile the project.
 You can find those files in the root of the project and in the `lib/` and `app/` folders.


### PR DESCRIPTION
Travis is a continuous integration platform, designed to compile and run our code each time it is pushed to github. This assures that bad pushes (broken unit tests for example, compile errors) are detected as fast as possible.

At the moment it runs on my fork, to finalize integration, @itko needs to set up travis on his account and change the two links in the [README.md](README.md)

Discuss and merge if this feature is desired.