### PR TITLE
Implemented Mean Shift algorithm

### DIFF
--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -70,7 +70,7 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 		}
 
 		if (clusters.size() != curr.size())
-			BOOST_LOG_TRIVIAL(warning) << "Cluster count does not equal mode count. (" << clusters.size() << " != " << curr.size();
+			BOOST_LOG_TRIVIAL(warning) << "Cluster count does not equal mode count. (" << clusters.size() << " != " << curr.size() << ")";
 
 		// Check convergence
 		if (prev.size() == curr.size()) {

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -37,7 +37,6 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 
 	// For each point...
 	for(PointIndex i = 0; i < clusters.size(); i++) {
-		prevCenter = points[i];
 		int iterations = 0; //for logging and abort condition
 
 		// ... iterate until convergence

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <math.h>
+#include <Eigen/Core>
 namespace MouseTrack {
 
 MeanShift::MeanShift(int k) : _k(k) {
@@ -42,17 +43,16 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 	return clustering;
 }
 
-double MeanShift::euclidean_distance_squared(const Point& x, const Point& y) {
-	return 	(x.x() - y.x())*(x.x() - y.x()) +
-					(x.y() - y.y())*(x.y() - y.y()) +
-					(x.z() - y.z())*(x.z() - y.z()) +
-					(x.intensity() - y.intensity())*(x.intensity() - y.intensity());
+double MeanShift::apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const PointIndex& mean) {
+	const GaussianKernel kernel = {means[mean], _window_size};
+
+	// Euclidean distance squared btw. mean of kernel and point of interest
+	const double d = euclidean_distance_squared(means[mean], cloud[point]);
+	return exp(-d/(2*_window_size));
 }
 
-double MeanShift::apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const GaussianKernel& kernel) {
-	// Euclidean distance squared btw. mean of kernel and point of interest
-	const double d = euclidean_distance_squared(kernel.mean, cloud[point]);
-	return exp(-d/(2*kernel.variance));
+Eigen::Vector4d MeanShift::create_vector(const PointCloud& cloud, const PointIndex& index) {
+	return Eigen::Vector4d()
 }
 
 } //MouseTrack

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -10,7 +10,6 @@
 #include <math.h>
 #include <boost/log/trivial.hpp>
 #include <Eigen/Dense>
-#include <iostream>
 
 namespace MouseTrack {
 
@@ -19,11 +18,54 @@ MeanShift::MeanShift(double window_size) : _window_size(window_size) {
 }
 
 std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
+	// Covert point cloud to Eigen vectors
+	std::vector<Eigen::VectorXd> points;
+	for (int i=0; i<cloud.size(); i++) {
+		points.push_back(cloud[i].eigenVec());
+	}
+
+	std::vector<Eigen::VectorXd> prev(points.size());
+	std::vector<Eigen::VectorXd> curr = points;
+	bool has_converged = false;
+
+	while (!has_converged) {
+
+		// perform 1 iteration on each mode
+		for (int i=0; i<prev.size(); i++) {
+			curr[i] = iterate_mode(prev[i], prev);
+		}
+
+		// Merge step
+		// For every mode..
+		for (int i=0; i<curr.size(); i++) {
+			// Check modes we haven't already executed the (i)-loop for
+			for (int j=i+1; i<curr.size(); j++) {
+				Eigen::VectorXd diff = curr[i] - curr[j];
+				if (diff.norm() < MERGE_THRESHOLD) {
+					curr.erase(curr.begin() + j);
+					break;
+				}
+			}
+		}
+
+		// Check convergence
+		if (prev.size() == curr.size()) {
+			double total_movement;
+			for (int i=0; i < curr.size(); i++) {
+				total_movement += (curr[i]-prev[i]).norm();
+			}
+			if (total_movement <= CONVERGENCE_THRESHOLD) has_converged = true;
+		}
+		prev = curr;
+	}
+	BOOST_LOG_TRIVIAL(trace) << "MeanShift converged! #Clusters: " << curr.size();
+
+	// Build clusters
 	std::vector<Cluster> clustering = std::vector<Cluster>();
 	return clustering;
 }
 
-double MeanShift::apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen::MatrixXd mean) const {
+double MeanShift::apply_gaussian_kernel(const Eigen::VectorXd point, const Eigen::VectorXd mean) const {
 
 	// check if dimensions match
 	if (mean.size() != point.size()) BOOST_LOG_TRIVIAL(error) << "Vector dimensions don't match";
@@ -33,6 +75,19 @@ double MeanShift::apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen
 
 	// Apply gaussian distribution
 	return exp(-d/(2*_window_size));
+}
+
+Eigen::VectorXd MeanShift::iterate_mode(const Eigen::VectorXd mode, const std::vector<Eigen::VectorXd>& state) const {
+	//COG Normalization Factor
+	double normfact = 0;
+	//Rest of COG
+	Eigen::VectorXd cog = Eigen::VectorXd::Zero(mode.size());
+	for(const Eigen::VectorXd x : state) {
+		double temp = apply_gaussian_kernel(x,mode);
+		normfact += temp;
+		cog += temp * x;
+	}
+	return cog * (1.0/normfact);
 }
 
 } //MouseTrack

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -61,7 +61,7 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 			Eigen::VectorXd diff = currCenters[i] - currCenters[j];
 			if (diff.norm() < _merge_threshold) {
 				// Merge clusters. Erase one of the modes corresponding to the clusters and append points belonging to j to cluser of i
-				clusters[i].points().insert(clusters[i].points().begin(), clusters[j].points().begin(), clusters[j].points().end());
+				clusters[i].points().push_back(j);
 				clusters.erase(clusters.begin() + j);
 				currCenters.erase(currCenters.begin() + j);
 				// We need to decrement i here because there might be another cluster that wants to merge with i.

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -58,8 +58,6 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 
 				if (diff.norm() < MERGE_THRESHOLD) {
 					// Merge clusters. Erase one of the modes corresponding to the clusters and append points belonging to j to cluser of i
-					//for (PointIndex k : clusters[j].points()) {
-
 					for (int k=0; k < clusters[j].points().size(); k++) {
 						clusters[i].points().push_back(clusters[j].points()[k]);
 					}

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -8,6 +8,7 @@
 #include "mean_shift.h"
 #include <stdlib.h>
 #include <time.h>
+#include <math.h>
 namespace MouseTrack {
 
 MeanShift::MeanShift(int k) : _k(k) {
@@ -39,6 +40,19 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 	clustering.erase(clustering.begin() + nextInsert, clustering.end());
 
 	return clustering;
+}
+
+double MeanShift::euclidean_distance_squared(const Point& x, const Point& y) {
+	return 	(x.x() - y.x())*(x.x() - y.x()) +
+					(x.y() - y.y())*(x.y() - y.y()) +
+					(x.z() - y.z())*(x.z() - y.z()) +
+					(x.intensity() - y.intensity())*(x.intensity() - y.intensity());
+}
+
+double MeanShift::apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const GaussianKernel& kernel) {
+	// Euclidean distance squared btw. mean of kernel and point of interest
+	const double d = euclidean_distance_squared(kernel.mean, cloud[point]);
+	return exp(-d/(2*kernel.variance));
 }
 
 } //MouseTrack

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -6,8 +6,6 @@
 
 
 #include "mean_shift.h"
-#include <stdlib.h>
-#include <math.h>
 #include <boost/log/trivial.hpp>
 #include <Eigen/Dense>
 

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -28,7 +28,10 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 
 	// Initialize Clusters. Initially, every point has its own cluster.
 	std::vector<Cluster> clusters(cloud.size());
-	for (PointIndex i; i<cloud.size(); i++) clusters[i].points().push_back(i);
+	for (PointIndex i=0; i<cloud.size(); i++) {
+		 clusters[i].points().push_back(i);
+
+	}
 
 	// Initialize some stuff used in the MeanShift loop
 	std::vector<Eigen::VectorXd> prev = points;
@@ -57,10 +60,12 @@ std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
 
 				if (diff.norm() < MERGE_THRESHOLD) {
 					// Merge clusters. Erase one of the modes corresponding to the clusters and append points belonging to j to cluser of i
-					for (PointIndex k : clusters[j].points()) {
-						clusters[i].points().push_back(k);
+					//for (PointIndex k : clusters[j].points()) {
+
+					for (int k=0; k < clusters[j].points().size(); k++) {
+						clusters[i].points().push_back(clusters[j].points()[k]);
 					}
-					BOOST_LOG_TRIVIAL(trace) << "Merging cluster " << j << " into cluster " << i << ", distance " << diff.norm();
+					//BOOST_LOG_TRIVIAL(debug) << "Merging cluster " << j << " into cluster " << i << ", distance " << diff.norm();
 					clusters.erase(clusters.begin() + j);
 					curr.erase(curr.begin() + j);
 

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -10,23 +10,22 @@
 #include <math.h>
 #include <boost/log/trivial.hpp>
 #include <Eigen/Dense>
+#include <iostream>
 
 namespace MouseTrack {
 
 MeanShift::MeanShift(double window_size) : _window_size(window_size) {
-    //empty
+	//empty
 }
 
 std::vector<Cluster> MeanShift::operator()(const PointCloud& cloud) const {
-
 	std::vector<Cluster> clustering = std::vector<Cluster>();
 	return clustering;
 }
 
-double MeanShift::apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& idx, Eigen::MatrixXd mean) const {
+double MeanShift::apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen::MatrixXd mean) const {
 
-	// Convert to Eigen type and check if dimensions match
-	Eigen::MatrixXd point = cloud[idx].eigenVec();
+	// check if dimensions match
 	if (mean.size() != point.size()) BOOST_LOG_TRIVIAL(error) << "Vector dimensions don't match";
 
 	// Euclidean distance squared btw. mean of kernel and point of interest

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -35,7 +35,4 @@ double MeanShift::apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen
 	return exp(-d/(2*_window_size));
 }
 
-void MeanShift::iterate() {
-	//TODO
-}
 } //MouseTrack

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -9,6 +9,7 @@
 #include "clustering.h"
 #include <vector>
 #include "generic/cluster.h"
+#include <Eigen/Core>
 
 namespace MouseTrack {
 
@@ -16,21 +17,19 @@ class MeanShift: public Clustering {
 public:
 
   /// k is the number of desired clusters
-  MeanShift(const int k);
+  MeanShift(double window_size);
   /// Splits a point cloud into k clusters randomly
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
 private:
-  const int _k;
-
   // window size parameter for mean shift algorithm
-  const double window_size;
+  double _window_size;
 
   // contains the means of all the mean shift clusters
   PointCloud means;
 
-  // Returns a weight in [0,1] for point w/ index "point" in "cloud" by applying a gaussian kernel with variance window_size and mean mean
-  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const Eigen::Vector4d mean);
+  // Returns a weight in [0,1] for point w/ index "idx" in "cloud" by applying a gaussian kernel with variance window_size and mean mean
+  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& idx, const Eigen::MatrixXd mean) const;
 
   // Performs one iteration of the mean shift algorithm
   void iterate();

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -25,6 +25,9 @@ private:
   // when two peaks are closer than this, they are merged.
   const double MERGE_THRESHOLD = 0.0001;
 
+  // Convergence is decided if modes haven't moved more than this in total
+  const double CONVERGENCE_THRESHOLD = 0.01;
+
   // window size parameter for mean shift algorithm
   double _window_size;
 
@@ -32,8 +35,10 @@ private:
   PointCloud means;
 
   // Returns a weight in [0,1] for point by applying a gaussian kernel with variance window_size and mean mean
-  double apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen::MatrixXd mean) const;
+  double apply_gaussian_kernel(const Eigen::VectorXd point, const Eigen::VectorXd mean) const;
 
+  // Performs one iteration of the mean shift algorithm for a single mode
+  Eigen::VectorXd iterate_mode(const Eigen::VectorXd mode, const std::vector<Eigen::VectorXd>& state) const;
 };
 
 }

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -28,8 +28,8 @@ private:
   // contains the means of all the mean shift clusters
   PointCloud means;
 
-  // Returns a weight in [0,1] for point w/ index "idx" in "cloud" by applying a gaussian kernel with variance window_size and mean mean
-  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& idx, const Eigen::MatrixXd mean) const;
+  // Returns a weight in [0,1] for point by applying a gaussian kernel with variance window_size and mean mean
+  double apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen::MatrixXd mean) const;
 
   // Performs one iteration of the mean shift algorithm
   void iterate();

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -26,7 +26,10 @@ private:
   const double MERGE_THRESHOLD = 0.0001;
 
   // Convergence is decided if modes haven't moved more than this in total
-  const double CONVERGENCE_THRESHOLD = 0.01;
+  const double CONVERGENCE_THRESHOLD = 0.1;
+
+  // If algorithm hasn't converged after this amount of iterations, we abort.
+  const int MAX_ITERATIONS = 100;
 
   // window size parameter for mean shift algorithm
   double _window_size;

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -21,7 +21,15 @@ public:
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
 private:
-    const int _k;
+  /// Defines a 4D gaussian kernel with mean and variance (variance is equal in each direction)
+  struct GaussianKernel {
+    Point mean;
+    double variance;
+  };
+  
+  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const GaussianKernel& kernel);
+
 };
+
 
 }

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -21,20 +21,19 @@ public:
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
 private:
+  const int _k;
 
+  // window size parameter for mean shift algorithm
+  const double window_size;
 
-  // computes squared euclidean distance ||x-y||. x and y are 4D (x,y,z,intensity)
-  double euclidean_distance_squared(const Point& x, const Point& y);
+  // contains the means of all the mean shift clusters
+  PointCloud means;
 
-  /// Returns a weight in [0,1] for point "point" in "cloud" by applying gaussian kernel "kernel"
-  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const GaussianKernel& kernel);
+  // Returns a weight in [0,1] for point w/ index "point" in "cloud" by applying a gaussian kernel with variance window_size and mean mean
+  double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const Eigen::Vector4d mean);
 
-};
-
-/// Defines a 4D gaussian kernel with mean and variance (variance is equal in each direction)
-struct GaussianKernel {
-  Point mean;
-  double variance;
+  // Performs one iteration of the mean shift algorithm
+  void iterate();
 };
 
 }

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -21,15 +21,20 @@ public:
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
 private:
-  /// Defines a 4D gaussian kernel with mean and variance (variance is equal in each direction)
-  struct GaussianKernel {
-    Point mean;
-    double variance;
-  };
-  
+
+
+  // computes squared euclidean distance ||x-y||. x and y are 4D (x,y,z,intensity)
+  double euclidean_distance_squared(const Point& x, const Point& y);
+
+  /// Returns a weight in [0,1] for point "point" in "cloud" by applying gaussian kernel "kernel"
   double apply_gaussian_kernel(const PointCloud& cloud, const PointIndex& point, const GaussianKernel& kernel);
 
 };
 
+/// Defines a 4D gaussian kernel with mean and variance (variance is equal in each direction)
+struct GaussianKernel {
+  Point mean;
+  double variance;
+};
 
 }

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -11,8 +11,18 @@
 #include "generic/cluster.h"
 #include <Eigen/Core>
 
-namespace MouseTrack {
+/// ***The Mean Shift Algorithm***
+/// Goal: assign each given point to a cluster based on the nearest local maximum of the point density.
+/// Algorithm:
+/// 1. At each point location, a cluster is initialized.
+/// 2. For each cluster i:
+///    i) Apply a gaussian kernel centered at the location of i to all points.
+///    ii) The new location of i is the weighted center of gravity of the points. Weights are given by the gaussian kernel.
+///    iii) Repeat i and ii until the location of i converges.
+/// 3. All clusters that are sufficiently close to each other are merged into one cluster.
+///
 
+namespace MouseTrack {
 class MeanShift: public Clustering {
 public:
 
@@ -21,26 +31,32 @@ public:
   /// Splits a point cloud into k clusters randomly
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
+  void setMaxIterations(int max_iterations);
+  int getMaxIterations() const;
+
+  void setMergeThreshold(double merge_threshold);
+  double getMergeThreshold() const;
+
+  void setConvergenceThreshold(double convergence_threshold);
+  double getConvergenceThreshold() const;
+
 private:
-  // when two peaks are closer than this, they are merged.
-  const double MERGE_THRESHOLD = 0.0001;
+  /// when two peaks are closer than this, they are merged. Must be larger than _convergence_threshold for convergence.
+  double _merge_threshold = 0.001;
 
-  // Convergence is decided if modes haven't moved more than this in total
-  const double CONVERGENCE_THRESHOLD = 0.1;
+  /// Convergence is decided if modes haven't moved more than this on average. Must be smaller than _merge_threshold for convergence.
+  double _convergence_threshold = 0.0001;
 
-  // If algorithm hasn't converged after this amount of iterations, we abort.
-  const int MAX_ITERATIONS = 100;
+  /// If algorithm hasn't converged after this amount of iterations, we abort.
+  int _max_iterations = 100;
 
-  // window size parameter for mean shift algorithm
+  /// window size parameter for mean shift algorithm
   double _window_size;
 
-  // contains the means of all the mean shift clusters
-  PointCloud means;
+  /// Returns a weight in [0,1] for point by applying a gaussian kernel with variance window_size and mean mean
+  double gaussian_weight(const Eigen::VectorXd point, const Eigen::VectorXd mean) const;
 
-  // Returns a weight in [0,1] for point by applying a gaussian kernel with variance window_size and mean mean
-  double apply_gaussian_kernel(const Eigen::VectorXd point, const Eigen::VectorXd mean) const;
-
-  // Performs one iteration of the mean shift algorithm for a single mode
+  /// Performs one iteration of the mean shift algorithm for a single mode
   Eigen::VectorXd iterate_mode(const Eigen::VectorXd mode, const std::vector<Eigen::VectorXd>& state) const;
 };
 

--- a/lib/clustering/mean_shift.h
+++ b/lib/clustering/mean_shift.h
@@ -22,6 +22,9 @@ public:
   std::vector<Cluster> operator()(const PointCloud& cloud) const;
 
 private:
+  // when two peaks are closer than this, they are merged.
+  const double MERGE_THRESHOLD = 0.0001;
+
   // window size parameter for mean shift algorithm
   double _window_size;
 
@@ -31,8 +34,6 @@ private:
   // Returns a weight in [0,1] for point by applying a gaussian kernel with variance window_size and mean mean
   double apply_gaussian_kernel(const Eigen::MatrixXd point, const Eigen::MatrixXd mean) const;
 
-  // Performs one iteration of the mean shift algorithm
-  void iterate();
 };
 
 }

--- a/lib/clustering/mean_shift.test.cc
+++ b/lib/clustering/mean_shift.test.cc
@@ -8,6 +8,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
 #include <stdlib.h>
+#include <random>
 
 
 namespace utf = boost::unit_test;
@@ -65,4 +66,42 @@ BOOST_AUTO_TEST_CASE( two_closetogether_points ) {
 
   std::vector<MouseTrack::Cluster> clusters = ms(pc);
   BOOST_CHECK_EQUAL(clusters.size(),1);
+}
+
+BOOST_AUTO_TEST_CASE( three_gaussian_clusters ) {
+  std::default_random_engine gen;
+
+  std::normal_distribution<double> gauss0(0.0,1.0);
+  std::normal_distribution<double> gauss10(10.0,1.0);
+
+  MouseTrack::PointCloud pc;
+  pc.resize(300);
+
+  MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
+
+  for (int i = 0; i<300; i+=3) {
+    pc[i].x() = gauss10(gen);
+    pc[i].y() = gauss0(gen);
+    pc[i].z() = gauss0(gen);
+    pc[i].intensity() = gauss0(gen);
+
+    pc[i+1].x() = gauss0(gen);
+    pc[i+1].y() = gauss10(gen);
+    pc[i+1].z() = gauss0(gen);
+    pc[i+1].intensity() = gauss0(gen);
+
+    pc[i+2].x() = gauss0(gen);
+    pc[i+2].y() = gauss0(gen);
+    pc[i+2].z() = gauss10(gen);
+    pc[i+2].intensity() = gauss0(gen);
+  }
+
+  std::vector<MouseTrack::Cluster> clusters = ms(pc);
+
+  BOOST_CHECK_EQUAL(clusters.size(),3);
+  BOOST_CHECK_EQUAL(clusters[0].points().size(),100);
+  BOOST_CHECK_EQUAL(clusters[1].points().size(),100);
+  BOOST_CHECK_EQUAL(clusters[2].points().size(),100);
+
+
 }

--- a/lib/clustering/mean_shift.test.cc
+++ b/lib/clustering/mean_shift.test.cc
@@ -14,6 +14,7 @@ namespace utf = boost::unit_test;
 
 
 BOOST_AUTO_TEST_CASE( mean_shift_read_write ) {
+  /*
     MouseTrack::PointCloud pc;
     const int pcsize = 8;
     pc.resize(pcsize);
@@ -40,5 +41,8 @@ BOOST_AUTO_TEST_CASE( mean_shift_read_write ) {
       npoints += clusters[i].points().size();
     }
     BOOST_CHECK_EQUAL(npoints,pcsize);
-
+*/
+MouseTrack::PointCloud pc;
+MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
+ms(pc);
 }

--- a/lib/clustering/mean_shift.test.cc
+++ b/lib/clustering/mean_shift.test.cc
@@ -7,42 +7,62 @@
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
-
+#include <stdlib.h>
 
 
 namespace utf = boost::unit_test;
 
 
 BOOST_AUTO_TEST_CASE( mean_shift_read_write ) {
-  /*
-    MouseTrack::PointCloud pc;
-    const int pcsize = 8;
-    pc.resize(pcsize);
-
-    for (int i=0; i<pcsize; i++) {
-      pc[i].x() = 1.0;
-      pc[i].y() = 2.0;
-      pc[i].z() = 3.0;
-      pc[i].intensity() = 4.0;
-    }
-
-    const int k = 3;
-
-    MouseTrack::MeanShift ms = MouseTrack::MeanShift(k);
-
-    std::vector<MouseTrack::Cluster> clusters = ms(pc);
-
-    //count all the points in clustering
-    int npoints = 0;
-
-    for(int i=0; i < clusters.size(); i++) {
-      //Clusters must not be empty
-      BOOST_CHECK(!clusters[i].points().empty());
-      npoints += clusters[i].points().size();
-    }
-    BOOST_CHECK_EQUAL(npoints,pcsize);
-*/
 MouseTrack::PointCloud pc;
 MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
 ms(pc);
+}
+
+BOOST_AUTO_TEST_CASE( mean_shift_single_point ) {
+  MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
+
+  MouseTrack::PointCloud pc;
+  pc.resize(1);
+  pc[0].x() = 0;
+  pc[0].y() = 3;
+  pc[0].z() = 5;
+  pc[0].intensity() = 1;
+
+  std::vector<MouseTrack::Cluster> clusters = ms(pc);
+  BOOST_CHECK_EQUAL(clusters.size(),1);
+}
+
+BOOST_AUTO_TEST_CASE( two_faraway_points ) {
+  MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
+  MouseTrack::PointCloud pc;
+  pc.resize(2);
+  pc[0].x() = 0;
+  pc[0].y() = 0;
+  pc[0].z() = 0;
+  pc[0].intensity() = 0;
+  pc[1].x() = 100;
+  pc[1].y() = 100;
+  pc[1].z() = 100;
+  pc[1].intensity() = 1;
+
+  std::vector<MouseTrack::Cluster> clusters = ms(pc);
+  BOOST_CHECK_EQUAL(clusters.size(),2);
+}
+
+BOOST_AUTO_TEST_CASE( two_closetogether_points ) {
+  MouseTrack::MeanShift ms = MouseTrack::MeanShift(1);
+  MouseTrack::PointCloud pc;
+  pc.resize(2);
+  pc[0].x() = 0;
+  pc[0].y() = 0;
+  pc[0].z() = 0;
+  pc[0].intensity() = 0;
+  pc[1].x() = 0.1;
+  pc[1].y() = 0.1;
+  pc[1].z() = 0.1;
+  pc[1].intensity() = 0;
+
+  std::vector<MouseTrack::Cluster> clusters = ms(pc);
+  BOOST_CHECK_EQUAL(clusters.size(),1);
 }

--- a/lib/clustering/mean_shift.test.cc
+++ b/lib/clustering/mean_shift.test.cc
@@ -1,5 +1,5 @@
 /// \file
-/// Maintainer: Felice Serena
+/// Maintainer: Luzian Hug
 ///
 ///
 

--- a/lib/generic/point_cloud.cpp
+++ b/lib/generic/point_cloud.cpp
@@ -69,6 +69,10 @@ const ColorChannel& PointCloud::Point::intensity() const {
     return _cloud._color[_index];
 }
 
+Eigen::MatrixXd PointCloud::Point::eigenVec() const {
+  return Eigen::Vector4D(x(),y(),z(),intensity());
+}
+
 
 // ConstantPoint implementation
 
@@ -91,6 +95,11 @@ const Coordinate& PointCloud::ConstantPoint::z() const {
 const ColorChannel& PointCloud::ConstantPoint::intensity() const {
     return _cloud._color[_index];
 }
+
+Eigen::MatrixXd PointCloud::ConstantPoint::eigenVec() const {
+  return Eigen::Vector4D(x(),y(),z(),intensity());
+}
+
 
 
 } // MouseTrack

--- a/lib/generic/point_cloud.cpp
+++ b/lib/generic/point_cloud.cpp
@@ -69,7 +69,7 @@ const ColorChannel& PointCloud::Point::intensity() const {
     return _cloud._color[_index];
 }
 
-Eigen::MatrixXd PointCloud::Point::eigenVec() const {
+Eigen::VectorXd PointCloud::Point::eigenVec() const {
   return Eigen::Vector4d(x(),y(),z(),intensity());
 }
 
@@ -96,7 +96,7 @@ const ColorChannel& PointCloud::ConstantPoint::intensity() const {
     return _cloud._color[_index];
 }
 
-Eigen::MatrixXd PointCloud::ConstantPoint::eigenVec() const {
+Eigen::VectorXd PointCloud::ConstantPoint::eigenVec() const {
   return Eigen::Vector4d(x(),y(),z(),intensity());
 }
 

--- a/lib/generic/point_cloud.cpp
+++ b/lib/generic/point_cloud.cpp
@@ -70,7 +70,7 @@ const ColorChannel& PointCloud::Point::intensity() const {
 }
 
 Eigen::MatrixXd PointCloud::Point::eigenVec() const {
-  return Eigen::Vector4D(x(),y(),z(),intensity());
+  return Eigen::Vector4d(x(),y(),z(),intensity());
 }
 
 
@@ -97,7 +97,7 @@ const ColorChannel& PointCloud::ConstantPoint::intensity() const {
 }
 
 Eigen::MatrixXd PointCloud::ConstantPoint::eigenVec() const {
-  return Eigen::Vector4D(x(),y(),z(),intensity());
+  return Eigen::Vector4d(x(),y(),z(),intensity());
 }
 
 

--- a/lib/generic/point_cloud.h
+++ b/lib/generic/point_cloud.h
@@ -61,7 +61,7 @@ public:
         const ColorChannel& intensity() const;
 
 				/// Convert to dx1 Eigen Matrix
-				Eigen::MatrixXd eigenVec() const;
+				Eigen::VectorXd eigenVec() const;
     };
 
     /// Exactly the same as `Point` but it only provides read-only access to the data.
@@ -86,7 +86,7 @@ public:
         const ColorChannel& intensity() const;
 
 				/// Convert to dx1 Eigen Matrix
-				Eigen::MatrixXd eigenVec() const;
+				Eigen::VectorXd eigenVec() const;
     };
 
     /// Make space to accomodate n points.

--- a/lib/generic/point_cloud.h
+++ b/lib/generic/point_cloud.h
@@ -83,6 +83,9 @@ public:
 
         /// Read access to color intensity.
         const ColorChannel& intensity() const;
+
+				/// Convert to dx1 Eigen Matrix
+				Eigen::MatrixXd eigenVec() const;
     };
 
     /// Make space to accomodate n points.

--- a/lib/generic/point_cloud.h
+++ b/lib/generic/point_cloud.h
@@ -25,7 +25,7 @@ class PointCloud {
 public:
 	/// The Point class is a collection of accessors allowing to manipulate the values inside the PointCloud in an intuitive way.
 	class Point {
-		// Design note: I tend to keep the hierarchy flat, 
+		// Design note: I tend to keep the hierarchy flat,
 		// this way we can implement it by storing a reference to the PointCloud
 		// and an index, and nothing more.
         friend class PointCloud;
@@ -58,6 +58,9 @@ public:
 
         /// Read access to color intensity.
         const ColorChannel& intensity() const;
+
+				/// Convert to dx1 Eigen Matrix
+				Eigen::MatrixXd eigenVec() const;
     };
 
     /// Exactly the same as `Point` but it only provides read-only access to the data.

--- a/lib/generic/point_cloud.h
+++ b/lib/generic/point_cloud.h
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <vector>
+#include <Eigen/Core>
 
 namespace MouseTrack {
 


### PR DESCRIPTION
This is my implementation of the Mean Shift algorithm tailored to our purposes.
Some notes:

- I added an eigenVec() function to PointCloud::Point to easily convert a point in a point cloud to an Eigen::VectorXd type. This is useful/necessary to perform operations on the points. It is a VectorXd instead of Vector4d so that we can easily add more dimensions if needed. This is useful/necessary to perform operations on the points.
- The algorithm passes all the unit tests I wrote. Namely: read/write, single point, two points, three gaussian-distributed clusters of 100 points each.
- As far as I can tell, it clusters all of the above examples "correctly". Of course there may still be bugs, I guess we'll find out when we use it in the implementation ;)
- I added some boost log messages - @Fluci did I understand correctly how to use them?
- Concerning efficiency. It is probable that this is not the most efficient way to implement it as I am not at all an expert in this topic - at one point I have three nested for loops which all loop over a potentially large amount of elements. Please feel free to comment on how to make my algorithm more efficient.