### PR TITLE
Fixed merging of Pipeline and TrajectoryBuilder

### DIFF
--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -311,7 +311,7 @@ void Pipeline::processFrame(FrameIndex f) {
         const auto descriptorIter = chain.descriptors().find(f);
         const Cluster& cluster = *(clusterIter->second);
         const std::shared_ptr<const ClusterDescriptor> descriptor = (descriptorIter->second);
-        controlPointsPtr->push_back((*_trajectoryBuilder)(descriptor, cluster));
+        controlPointsPtr->push_back((*_trajectoryBuilder)(descriptor, cluster, *rawPointCloud));
     }
 
     std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints{std::move(controlPointsPtr)};

--- a/app/pipeline_factory.cpp
+++ b/app/pipeline_factory.cpp
@@ -9,6 +9,7 @@
 #include "clustering/mean_shift.h"
 #include "descripting/cog.h"
 #include "matching/nearest_neighbour.h"
+#include "trajectory_builder/cog_trajectory_builder.h"
 #include <boost/log/trivial.hpp>
 
 namespace MouseTrack {
@@ -32,7 +33,7 @@ Pipeline PipelineFactory::fromCliOptions(const op::variables_map& options) const
     std::unique_ptr<Clustering> clustering{new MeanShift(10)};
     std::unique_ptr<Descripting> descripting{new CenterOfGravity()};
     std::unique_ptr<Matching> matching{new NearestNeighbour()};
-    std::unique_ptr<TrajectoryBuilder> trajectoryBuilder;
+    std::unique_ptr<TrajectoryBuilder> trajectoryBuilder{new CogTrajectoryBuilder()};
     return Pipeline(
                 std::move(reader),
                 std::move(registration),


### PR DESCRIPTION
The last TrajectoryBulider merge changed the interface but the pipeline used the old one. I fixed it. 
The entire pipeline should now run through successfully. 