### PR TITLE
Updated pipeline.cpp to acommodate trajectory builder interface change

### DIFF
--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -311,7 +311,7 @@ void Pipeline::processFrame(FrameIndex f) {
         const auto descriptorIter = chain.descriptors().find(f);
         const Cluster& cluster = *(clusterIter->second);
         const std::shared_ptr<const ClusterDescriptor> descriptor = (descriptorIter->second);
-        controlPointsPtr->push_back((*_trajectoryBuilder)(descriptor, cluster));
+        controlPointsPtr->push_back((*_trajectoryBuilder)(descriptor, cluster, *rawPointCloud));
     }
 
     std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints{std::move(controlPointsPtr)};


### PR DESCRIPTION
I changed the trajecotry_builder.h interface when I made the trajectory builder, but pipeline.cpp still used the old one. This is now fixed.