### PR TITLE
Added interface for FrameWindowFiltering

### DIFF
--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -42,6 +42,7 @@ Pipeline::~Pipeline() noexcept(true) {
 void Pipeline::moveMembersFrom(Pipeline &p) {
   _observers = std::move(p._observers);
   _reader = std::move(p._reader);
+  _frameWindowFiltering = std::move(p._frameWindowFiltering);
   _registration = std::move(p._registration);
   _cloudFiltering = std::move(p._cloudFiltering);
   _clustering = std::move(p._clustering);

--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -16,8 +16,9 @@ Pipeline::Pipeline()
 }
 
 Pipeline::Pipeline(std::unique_ptr<Reader> reader,
+                   std::unique_ptr<FrameWindowFiltering> windowFiltering,
                    std::unique_ptr<Registration> registration,
-                   std::unique_ptr<PointCloudFiltering> filtering,
+                   std::unique_ptr<PointCloudFiltering> cloudFiltering,
                    std::unique_ptr<Clustering> clustering,
                    std::unique_ptr<Descripting> descripting,
                    std::unique_ptr<Matching> matching,
@@ -25,8 +26,10 @@ Pipeline::Pipeline(std::unique_ptr<Reader> reader,
     : _controller_should_run(false), _controller_running(false),
       _controller_terminated(true), _reader(std::move(reader)),
       _registration(std::move(registration)),
-      _cloudFiltering(std::move(filtering)), _clustering(std::move(clustering)),
-      _descripting(std::move(descripting)), _matching(std::move(matching)),
+      _frameWindowFiltering(std::move(windowFiltering)),
+      _cloudFiltering(std::move(cloudFiltering)),
+      _clustering(std::move(clustering)), _descripting(std::move(descripting)),
+      _matching(std::move(matching)),
       _trajectoryBuilder(std::move(trajectoryBuilder)) {
   // empty
 }
@@ -208,6 +211,24 @@ void Pipeline::processFrame(FrameIndex f) {
   if (terminateEarly()) {
     forallObservers([=](PipelineObserver *o) { o->frameEnd(f); });
     return;
+  }
+
+  // optional: frame window point cloud
+  if (_frameWindowFiltering != nullptr) {
+    forallObservers(
+        [=](PipelineObserver *o) { o->startFrameWindowFiltering(f); });
+    std::unique_ptr<FrameWindow> filteredFrameWindowPtr(new FrameWindow());
+    (*filteredFrameWindowPtr) = (*_frameWindowFiltering)(*window);
+    // replace raw frame window
+    window =
+        std::shared_ptr<const FrameWindow>{std::move(filteredFrameWindowPtr)};
+    forallObservers(
+        [=](PipelineObserver *o) { o->newFilteredFrameWindow(f, window); });
+
+    if (terminateEarly()) {
+      forallObservers([=](PipelineObserver *o) { o->frameEnd(f); });
+      return;
+    }
   }
 
   // get raw point cloud

--- a/app/pipeline.h
+++ b/app/pipeline.h
@@ -7,6 +7,7 @@
 
 #include "clustering/clustering.h"
 #include "descripting/descripting.h"
+#include "frame_window_filtering/frame_window_filtering.h"
 #include "matching/matching.h"
 #include "pipeline_observer.h"
 #include "point_cloud_filtering/point_cloud_filtering.h"
@@ -40,8 +41,9 @@ public:
 
   /// The first module pointer with a nullptr defines the end of the pipeline.
   Pipeline(std::unique_ptr<Reader> reader,
+           std::unique_ptr<FrameWindowFiltering> windowFiltering,
            std::unique_ptr<Registration> registration,
-           std::unique_ptr<PointCloudFiltering> filtering,
+           std::unique_ptr<PointCloudFiltering> cloudFiltering,
            std::unique_ptr<Clustering> clustering,
            std::unique_ptr<Descripting> descripting,
            std::unique_ptr<Matching> matching,
@@ -131,6 +133,7 @@ private:
   // pipeline steps
 
   std::unique_ptr<Reader> _reader;
+  std::unique_ptr<FrameWindowFiltering> _frameWindowFiltering;
   std::unique_ptr<Registration> _registration;
   std::unique_ptr<PointCloudFiltering> _cloudFiltering;
   std::unique_ptr<Clustering> _clustering;

--- a/app/pipeline_factory.cpp
+++ b/app/pipeline_factory.cpp
@@ -43,7 +43,7 @@ PipelineFactory::fromCliOptions(const op::variables_map &options) const {
   std::unique_ptr<Matching> matching{new NearestNeighbour()};
   std::unique_ptr<TrajectoryBuilder> trajectoryBuilder{
       new CogTrajectoryBuilder()};
-  return Pipeline(std::move(reader), std::move(registration),
+  return Pipeline(std::move(reader), nullptr, std::move(registration),
                   std::move(cloudFiltering), std::move(clustering),
                   std::move(descripting), std::move(matching),
                   std::move(trajectoryBuilder));

--- a/app/pipeline_observer.cpp
+++ b/app/pipeline_observer.cpp
@@ -35,6 +35,15 @@ void PipelineObserver::newFrameWindow(
   // empty
 }
 
+void PipelineObserver::startFrameWindowFiltering(FrameIndex f) {
+  // empty
+}
+
+void PipelineObserver::newFilteredFrameWindow(
+    FrameIndex f, std::shared_ptr<const FrameWindow> window) {
+  // empty
+}
+
 void PipelineObserver::startRegistration(FrameIndex f) {
   // empty
 }

--- a/app/pipeline_observer.h
+++ b/app/pipeline_observer.h
@@ -75,6 +75,9 @@ public:
     virtual void startFrameWindow     (FrameIndex f);
     virtual void newFrameWindow       (FrameIndex f, std::shared_ptr<const FrameWindow> window);
 
+    virtual void startFrameWindowFiltering(FrameIndex f);
+    virtual void newFilteredFrameWindow(FrameIndex f, std::shared_ptr<const FrameWindow> window);
+
     virtual void startRegistration    (FrameIndex f);
     virtual void newRawPointCloud     (FrameIndex f, std::shared_ptr<const PointCloud> cloud);
 

--- a/app/pipeline_timer.cpp
+++ b/app/pipeline_timer.cpp
@@ -25,6 +25,15 @@ void PipelineTimer::newFrameWindow(FrameIndex f,
   stopTimer(f, "readFrameWindow");
 }
 
+void PipelineTimer::startFrameWindowFiltering(FrameIndex f) {
+  startTimer(f, "frameWindowFiltering");
+}
+
+void PipelineTimer::newFilteredFrameWindow(
+    FrameIndex f, std::shared_ptr<const FrameWindow> window) {
+  stopTimer(f, "frameWindowFiltering");
+}
+
 void PipelineTimer::startRegistration(FrameIndex f) {
   startTimer(f, "registration");
 }

--- a/app/pipeline_timer.h
+++ b/app/pipeline_timer.h
@@ -23,6 +23,11 @@ public:
   virtual void newFrameWindow(FrameIndex f,
                               std::shared_ptr<const FrameWindow> window);
 
+  virtual void startFrameWindowFiltering(FrameIndex f);
+  virtual void
+  newFilteredFrameWindow(FrameIndex f,
+                         std::shared_ptr<const FrameWindow> window);
+
   virtual void startRegistration(FrameIndex f);
   virtual void newRawPointCloud(FrameIndex f,
                                 std::shared_ptr<const PointCloud> cloud);

--- a/lib/frame_window_filtering/frame_window_filtering.h
+++ b/lib/frame_window_filtering/frame_window_filtering.h
@@ -1,0 +1,17 @@
+/// \file
+/// Maintainer: Felice Serena
+///
+
+#pragma once
+
+#include "generic/frame_window.h"
+
+namespace MouseTrack {
+
+class FrameWindowFiltering {
+public:
+  virtual ~FrameWindowFiltering() = default;
+  virtual FrameWindow operator()(const FrameWindow &window) const = 0;
+};
+
+} // namespace MouseTrack


### PR DESCRIPTION
As inspired by the beehive project in the lecture today, here's the skeleton for the filtering of the input images.

There is no actual filter yet and I want to wait for the merge of #26 before I add new command line options.

I've also added a card to trello: I want to give some way of stacking filters (for point clouds and for frame windows) since it's a very natural thing to do, but I still struggle with the CLI syntax to allow repeating modules with parameters. Any ideas welcome.