### PR TITLE
Added pipeline Delegate

### DIFF
--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -136,6 +136,8 @@ void Pipeline::_join() {
 
 void Pipeline::setDelegate(PipelineDelegate *delegate) {
   std::lock_guard<std::mutex> lock(_observer_mutex);
+  // note: this cases tries to catch undefined behavior but it is not thread
+  // safe
   if (delegate == nullptr && !_controller_terminated) {
     throw "It is invalid to set the delegate to nullptr while the pipeline is "
           "running";

--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -16,7 +16,7 @@ Pipeline::Pipeline()
   BOOST_LOG_TRIVIAL(debug) << "Constructing pipeline.";
 }
 
-  // clang-format off
+// clang-format off
 Pipeline::Pipeline(std::unique_ptr<Reader> reader,
                    std::unique_ptr<FrameWindowFiltering> windowFiltering,
                    std::unique_ptr<Registration> registration,
@@ -32,7 +32,7 @@ Pipeline::Pipeline(std::unique_ptr<Reader> reader,
       _frameWindowFiltering(std::move(windowFiltering)),
       _reader(std::move(reader)), 
       _registration(std::move(registration)),
-      _cloudFiltering(std::move(filtering)), 
+      _cloudFiltering(std::move(cloudFiltering)),
       _clustering(std::move(clustering)),
       _descripting(std::move(descripting)), 
       _matching(std::move(matching)),
@@ -409,4 +409,4 @@ void Pipeline::processFrame(FrameNumber f) {
   forallObservers([=](PipelineObserver *o) { o->frameEnd(f); });
 }
 
-} // MouseTrack
+} // namespace MouseTrack

--- a/app/pipeline.h
+++ b/app/pipeline.h
@@ -8,6 +8,7 @@
 #include "clustering/clustering.h"
 #include "descripting/descripting.h"
 #include "matching/matching.h"
+#include "pipeline_delegate.h"
 #include "pipeline_observer.h"
 #include "point_cloud_filtering/point_cloud_filtering.h"
 #include "reader/reader.h"
@@ -81,9 +82,14 @@ public:
 
   void removeObserver(PipelineObserver *observer);
 
+  void setDelegate(PipelineDelegate *delegate);
+
 private:
+  /// This mutex regulates communication with the outside
+  /// (observers and delegate)
   mutable std::mutex _observer_mutex;
   std::set<PipelineObserver *> _observers;
+  PipelineDelegate *_delegate;
 
   /// main worker thread, coordinates work distribution and communicates with
   /// observer
@@ -106,7 +112,7 @@ private:
   void controllerStart();
 
   /// coordinates pipeline for one frame
-  void processFrame(FrameIndex f);
+  void processFrame(FrameNumber f);
 
   template <typename Lambda> void forallObservers(Lambda lambda) {
     std::lock_guard<std::mutex> lock(_observer_mutex);

--- a/app/pipeline.h
+++ b/app/pipeline.h
@@ -23,10 +23,11 @@ namespace MouseTrack {
 
 /// This object is responsible to coordinate the processing steps
 ///
-/// - It knows how to acquire new frames
+/// - It knows how to acquire new frames (reader or delegate)
 /// - It knows how to push the frames through the pipeline steps
 /// - It informs other objects about (inbetween-)results via an observer pattern
 /// (PipelineObserver)
+/// - An optional PipelineDelegate can be set to micromanage pipeline execution.
 ///
 /// The pipeline runs one or multiple worker threads to process the frame stream
 /// concurrently. Start the processing with `start()`. If you want to terminate
@@ -82,6 +83,17 @@ public:
 
   void removeObserver(PipelineObserver *observer);
 
+  /// Sets a pointer to a delegate object
+  /// You can change the delegate at runtime (all operations are atomic) only to
+  /// another valid object.
+  ///
+  /// Note: The new delegate will have to take over at an arbitrary point, so
+  /// both delegates need to be synchronized. For your own safety, just pause
+  /// the pipeline and restart it.
+  ///
+  /// Warning: You are not allowed to set the delegate to
+  /// `nullptr`, while the pipeline is running. In this case, behavior is
+  /// undefined.
   void setDelegate(PipelineDelegate *delegate);
 
 private:
@@ -119,6 +131,11 @@ private:
     for (PipelineObserver *o : _observers) {
       lambda(o);
     }
+  }
+
+  template <typename Lambda> auto askDelegate(Lambda lambda) {
+    std::lock_guard<std::mutex> lock(_observer_mutex);
+    return lambda(_delegate);
   }
 
   /// Helper for move operations: moves all relevant data members (not mutexes,

--- a/app/pipeline_delegate.h
+++ b/app/pipeline_delegate.h
@@ -1,0 +1,25 @@
+/// \file
+/// Maintainer: Felice Serena
+///
+
+#pragma once
+
+#include "generic/types.h"
+
+namespace MouseTrack {
+
+/// Implement this interface if you want to control the pipeline
+/// at run time in an interactive manner.
+class PipelineDelegate {
+public:
+  virtual ~PipelineDelegate() = default;
+
+  /// `true` if there exists a frame to process.
+  /// `false` if no more frames are available.
+  virtual bool hasNextFrame() const = 0;
+
+  /// Returns the frame number that should be processed
+  /// in the next run of the pipeline
+  virtual FrameNumber nextFrame() = 0;
+};
+} // namespace MouseTrack

--- a/app/pipeline_observer.cpp
+++ b/app/pipeline_observer.cpp
@@ -16,78 +16,80 @@ void PipelineObserver::pipelineTerminated() {
 }
 
 void PipelineObserver::newClusterChains(
-    std::shared_ptr<const std::vector<ClusterChain>> chains) {}
-
-void PipelineObserver::frameStart(FrameIndex frame) {
+    std::shared_ptr<const std::vector<ClusterChain>> chains) {
   // empty
 }
 
-void PipelineObserver::frameEnd(FrameIndex frame) {
+void PipelineObserver::frameStart(FrameNumber frame) {
   // empty
 }
 
-void PipelineObserver::startFrameWindow(FrameIndex f) {
+void PipelineObserver::frameEnd(FrameNumber frame) {
+  // empty
+}
+
+void PipelineObserver::startFrameWindow(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newFrameWindow(
-    FrameIndex f, std::shared_ptr<const FrameWindow> window) {
+    FrameNumber f, std::shared_ptr<const FrameWindow> window) {
   // empty
 }
 
-void PipelineObserver::startRegistration(FrameIndex f) {
+void PipelineObserver::startRegistration(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newRawPointCloud(
-    FrameIndex f, std::shared_ptr<const PointCloud> cloud) {
+    FrameNumber f, std::shared_ptr<const PointCloud> cloud) {
   // empty
 }
 
-void PipelineObserver::startPointCloudFiltering(FrameIndex f) {
+void PipelineObserver::startPointCloudFiltering(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newFilteredPointCloud(
-    FrameIndex f, std::shared_ptr<const PointCloud> cloud) {
+    FrameNumber f, std::shared_ptr<const PointCloud> cloud) {
   // empty
 }
 
-void PipelineObserver::startClustering(FrameIndex f) {
+void PipelineObserver::startClustering(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newClusters(
-    FrameIndex f, std::shared_ptr<const std::vector<Cluster>> cluster) {
+    FrameNumber f, std::shared_ptr<const std::vector<Cluster>> cluster) {
   // empty
 }
 
-void PipelineObserver::startDescripting(FrameIndex f) {
+void PipelineObserver::startDescripting(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newDescriptors(
-    FrameIndex f,
+    FrameNumber f,
     std::shared_ptr<const std::vector<std::shared_ptr<const ClusterDescriptor>>>
         descriptors) {
   // empty
 }
 
-void PipelineObserver::startMatching(FrameIndex f) {
+void PipelineObserver::startMatching(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newMatches(
-    FrameIndex f, std::shared_ptr<const std::vector<long>> matches) {
+    FrameNumber f, std::shared_ptr<const std::vector<long>> matches) {
   // empty
 }
 
-void PipelineObserver::startControlPoints(FrameIndex f) {
+void PipelineObserver::startControlPoints(FrameNumber f) {
   // empty
 }
 
 void PipelineObserver::newControlPoints(
-    FrameIndex f,
+    FrameNumber f,
     std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints) {
   // empty
 }

--- a/app/pipeline_observer.h
+++ b/app/pipeline_observer.h
@@ -4,14 +4,15 @@
 
 #pragma once
 
-#include "generic/frame_window.h"
 #include "generic/types.h"
-// Mocks: remove after merge
-typedef int FrameIndex;
+[[deprecated(
+    "Please use MouseTrack::FrameNumber")]] typedef MouseTrack::FrameNumber
+    FrameIndex;
 
 #include "generic/cluster.h"
 #include "generic/cluster_chain.h"
 #include "generic/cluster_descriptor.h"
+#include "generic/frame_window.h"
 #include "generic/point_cloud.h"
 
 #include <Eigen/Core>
@@ -41,15 +42,18 @@ namespace MouseTrack {
 ///
 /// - No concurrent calls: Only one method is called at a time by only one
 /// thread.
-/// - Sequential FrameIndexes: It is guaranteed, that calls with the same frame
-/// index
-///   are called in orderd. It is also guaranteed, that for a processing step,
+/// - Sequential FrameNumbers: It is guaranteed, that calls with the same frame
+/// number are called in order.
+///   It is also guaranteed, that for a processing step,
 ///   the passed frame indices increase monotonically.
 ///   Example: frameStart(2) always is called before frameStart(3).
 ///   startFrameWindow(2) is always called before newFrameWindow(2).
+///   Don't rely on any other ordering (frameEnd(2) and frameStart(3) can come
+///   in any order).
 ///
 /// Notes:
-/// - You don't need to impement all methods. By default, each method is a noop.
+/// - You don't need to implement all methods. By default, each method is a
+/// noop.
 class PipelineObserver {
 public:
   /// Pipeline starts to process data
@@ -64,34 +68,34 @@ public:
   newClusterChains(std::shared_ptr<const std::vector<ClusterChain>> chains);
 
   /// Work on frame `frame` started, it is inside the pipeline.
-  virtual void frameStart(FrameIndex frame);
+  virtual void frameStart(FrameNumber frame);
 
   /// Work on frame `frame` finished, it is no longer processed by the pipeline.
-  virtual void frameEnd(FrameIndex frame);
+  virtual void frameEnd(FrameNumber frame);
 
   // see descriptions of the corresponding module interfaces
 
   // clang-format off
-    virtual void startFrameWindow     (FrameIndex f);
-    virtual void newFrameWindow       (FrameIndex f, std::shared_ptr<const FrameWindow> window);
+    virtual void startFrameWindow     (FrameNumber f);
+    virtual void newFrameWindow       (FrameNumber f, std::shared_ptr<const FrameWindow> window);
 
-    virtual void startRegistration    (FrameIndex f);
-    virtual void newRawPointCloud     (FrameIndex f, std::shared_ptr<const PointCloud> cloud);
+    virtual void startRegistration    (FrameNumber f);
+    virtual void newRawPointCloud     (FrameNumber f, std::shared_ptr<const PointCloud> cloud);
 
-    virtual void startPointCloudFiltering(FrameIndex f);
-    virtual void newFilteredPointCloud(FrameIndex f, std::shared_ptr<const PointCloud> cloud);
+    virtual void startPointCloudFiltering(FrameNumber f);
+    virtual void newFilteredPointCloud(FrameNumber f, std::shared_ptr<const PointCloud> cloud);
 
-    virtual void startClustering      (FrameIndex f);
-    virtual void newClusters          (FrameIndex f, std::shared_ptr<const std::vector<Cluster>> clusters);
+    virtual void startClustering      (FrameNumber f);
+    virtual void newClusters          (FrameNumber f, std::shared_ptr<const std::vector<Cluster>> clusters);
 
-    virtual void startDescripting     (FrameIndex f);
-    virtual void newDescriptors       (FrameIndex f, std::shared_ptr<const std::vector<std::shared_ptr<const ClusterDescriptor>>> descriptors);
+    virtual void startDescripting     (FrameNumber f);
+    virtual void newDescriptors       (FrameNumber f, std::shared_ptr<const std::vector<std::shared_ptr<const ClusterDescriptor>>> descriptors);
 
-    virtual void startMatching        (FrameIndex f);
-    virtual void newMatches           (FrameIndex f, std::shared_ptr<const std::vector<long>> matches);
+    virtual void startMatching        (FrameNumber f);
+    virtual void newMatches           (FrameNumber f, std::shared_ptr<const std::vector<long>> matches);
 
-    virtual void startControlPoints   (FrameIndex f);
-    virtual void newControlPoints     (FrameIndex f, std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints);
+    virtual void startControlPoints   (FrameNumber f);
+    virtual void newControlPoints     (FrameNumber f, std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints);
   // clang-format on
 };
 } // namespace MouseTrack

--- a/app/pipeline_timer.cpp
+++ b/app/pipeline_timer.cpp
@@ -12,77 +12,77 @@ void PipelineTimer::pipelineStarted() { startTimer(-1, "pipeline"); }
 
 void PipelineTimer::pipelineTerminated() { stopTimer(-1, "pipeline"); }
 
-void PipelineTimer::frameStart(FrameIndex f) { startTimer(f, "total"); }
+void PipelineTimer::frameStart(FrameNumber f) { startTimer(f, "total"); }
 
-void PipelineTimer::frameEnd(FrameIndex f) { stopTimer(f, "total"); }
+void PipelineTimer::frameEnd(FrameNumber f) { stopTimer(f, "total"); }
 
-void PipelineTimer::startFrameWindow(FrameIndex f) {
+void PipelineTimer::startFrameWindow(FrameNumber f) {
   startTimer(f, "readFrameWindow");
 }
 
-void PipelineTimer::newFrameWindow(FrameIndex f,
+void PipelineTimer::newFrameWindow(FrameNumber f,
                                    std::shared_ptr<const FrameWindow> window) {
   stopTimer(f, "readFrameWindow");
 }
 
-void PipelineTimer::startRegistration(FrameIndex f) {
+void PipelineTimer::startRegistration(FrameNumber f) {
   startTimer(f, "registration");
 }
 
-void PipelineTimer::newRawPointCloud(FrameIndex f,
+void PipelineTimer::newRawPointCloud(FrameNumber f,
                                      std::shared_ptr<const PointCloud> cloud) {
   stopTimer(f, "registration");
 }
 
-void PipelineTimer::startPointCloudFiltering(FrameIndex f) {
+void PipelineTimer::startPointCloudFiltering(FrameNumber f) {
   startTimer(f, "point_cloud_filtering");
 }
 
 void PipelineTimer::newFilteredPointCloud(
-    FrameIndex f, std::shared_ptr<const PointCloud> cloud) {
+    FrameNumber f, std::shared_ptr<const PointCloud> cloud) {
   stopTimer(f, "point_cloud_filtering");
 }
 
-void PipelineTimer::startClustering(FrameIndex f) {
+void PipelineTimer::startClustering(FrameNumber f) {
   startTimer(f, "clustering");
 }
 
 void PipelineTimer::newClusters(
-    FrameIndex f, std::shared_ptr<const std::vector<Cluster>> clusters) {
+    FrameNumber f, std::shared_ptr<const std::vector<Cluster>> clusters) {
   stopTimer(f, "clustering");
 }
 
-void PipelineTimer::startDescripting(FrameIndex f) {
+void PipelineTimer::startDescripting(FrameNumber f) {
   startTimer(f, "descripting");
 }
 
 void PipelineTimer::newDescriptors(
-    FrameIndex f,
+    FrameNumber f,
     std::shared_ptr<const std::vector<std::shared_ptr<const ClusterDescriptor>>>
         descriptors) {
   stopTimer(f, "descripting");
 }
 
-void PipelineTimer::startMatching(FrameIndex f) { startTimer(f, "matching"); }
+void PipelineTimer::startMatching(FrameNumber f) { startTimer(f, "matching"); }
 
 void PipelineTimer::newMatches(
-    FrameIndex f, std::shared_ptr<const std::vector<long>> matches) {
+    FrameNumber f, std::shared_ptr<const std::vector<long>> matches) {
   stopTimer(f, "matching");
 }
-void PipelineTimer::startControlPoints(FrameIndex f) {
+void PipelineTimer::startControlPoints(FrameNumber f) {
   startTimer(f, "controlPoints");
 }
 void PipelineTimer::newControlPoints(
-    FrameIndex f,
+    FrameNumber f,
     std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints) {
   stopTimer(f, "controlPoints");
 }
 
-void PipelineTimer::startTimer(FrameIndex f, const std::string &key) {
+void PipelineTimer::startTimer(FrameNumber f, const std::string &key) {
   _starts[Key(f, key)] = std::chrono::system_clock::now();
 }
 
-void PipelineTimer::stopTimer(FrameIndex f, const std::string &key) {
+void PipelineTimer::stopTimer(FrameNumber f, const std::string &key) {
   auto start = _starts.find(Key(f, key));
   if (start == _starts.end()) {
     BOOST_LOG_TRIVIAL(warning)

--- a/app/pipeline_timer.h
+++ b/app/pipeline_timer.h
@@ -15,47 +15,47 @@ public:
 
   virtual void pipelineTerminated();
 
-  virtual void frameStart(FrameIndex frame);
+  virtual void frameStart(FrameNumber frame);
 
-  virtual void frameEnd(FrameIndex frame);
+  virtual void frameEnd(FrameNumber frame);
 
-  virtual void startFrameWindow(FrameIndex f);
-  virtual void newFrameWindow(FrameIndex f,
+  virtual void startFrameWindow(FrameNumber f);
+  virtual void newFrameWindow(FrameNumber f,
                               std::shared_ptr<const FrameWindow> window);
 
-  virtual void startRegistration(FrameIndex f);
-  virtual void newRawPointCloud(FrameIndex f,
+  virtual void startRegistration(FrameNumber f);
+  virtual void newRawPointCloud(FrameNumber f,
                                 std::shared_ptr<const PointCloud> cloud);
 
-  virtual void startPointCloudFiltering(FrameIndex f);
-  virtual void newFilteredPointCloud(FrameIndex f,
+  virtual void startPointCloudFiltering(FrameNumber f);
+  virtual void newFilteredPointCloud(FrameNumber f,
                                      std::shared_ptr<const PointCloud> cloud);
 
-  virtual void startClustering(FrameIndex f);
+  virtual void startClustering(FrameNumber f);
   virtual void
-  newClusters(FrameIndex f,
+  newClusters(FrameNumber f,
               std::shared_ptr<const std::vector<Cluster>> clusters);
 
-  virtual void startDescripting(FrameIndex f);
+  virtual void startDescripting(FrameNumber f);
   virtual void newDescriptors(
-      FrameIndex f,
+      FrameNumber f,
       std::shared_ptr<
           const std::vector<std::shared_ptr<const ClusterDescriptor>>>
           descriptors);
 
-  virtual void startMatching(FrameIndex f);
-  virtual void newMatches(FrameIndex f,
+  virtual void startMatching(FrameNumber f);
+  virtual void newMatches(FrameNumber f,
                           std::shared_ptr<const std::vector<long>> matches);
 
-  virtual void startControlPoints(FrameIndex f);
+  virtual void startControlPoints(FrameNumber f);
   virtual void newControlPoints(
-      FrameIndex f,
+      FrameNumber f,
       std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints);
 
 private:
-  typedef std::pair<FrameIndex, std::string> Key;
-  void startTimer(FrameIndex f, const std::string &key);
-  void stopTimer(FrameIndex f, const std::string &key);
+  typedef std::pair<FrameNumber, std::string> Key;
+  void startTimer(FrameNumber f, const std::string &key);
+  void stopTimer(FrameNumber f, const std::string &key);
   std::map<Key, std::chrono::system_clock::time_point> _starts;
 };
 

--- a/app/pipeline_writer.cpp
+++ b/app/pipeline_writer.cpp
@@ -32,7 +32,7 @@ PipelineWriter::PipelineWriter(fs::path targetDir)
   }
 }
 
-void PipelineWriter::newRawPointCloud(FrameIndex f,
+void PipelineWriter::newRawPointCloud(FrameNumber f,
                                       std::shared_ptr<const PointCloud> cloud) {
   _clouds[f] = cloud;
   fs::path path = _outputDir / insertFrame(_rawPointCloudPath, f);
@@ -40,7 +40,7 @@ void PipelineWriter::newRawPointCloud(FrameIndex f,
 }
 
 void PipelineWriter::newFilteredPointCloud(
-    FrameIndex f, std::shared_ptr<const PointCloud> cloud) {
+    FrameNumber f, std::shared_ptr<const PointCloud> cloud) {
   // overwrite rawPointCloud
   _clouds[f] = cloud;
 
@@ -49,7 +49,7 @@ void PipelineWriter::newFilteredPointCloud(
 }
 
 void PipelineWriter::newClusters(
-    FrameIndex f, std::shared_ptr<const std::vector<Cluster>> clusters) {
+    FrameNumber f, std::shared_ptr<const std::vector<Cluster>> clusters) {
   _clusters[f] = clusters;
   std::vector<std::vector<PointIndex>> tmp;
   tmp.reserve(clusters->size());
@@ -85,14 +85,14 @@ void PipelineWriter::newClusters(
 }
 
 void PipelineWriter::newDescriptors(
-    FrameIndex,
+    FrameNumber,
     std::shared_ptr<
         const std::vector<std::shared_ptr<const ClusterDescriptor>>>) {
   // empty
 }
 
 void PipelineWriter::newMatches(
-    FrameIndex f, std::shared_ptr<const std::vector<long>> matches) {
+    FrameNumber f, std::shared_ptr<const std::vector<long>> matches) {
   std::vector<std::vector<long>> tmp;
   tmp.push_back(*matches);
 
@@ -101,7 +101,7 @@ void PipelineWriter::newMatches(
 }
 
 void PipelineWriter::newControlPoints(
-    FrameIndex f,
+    FrameNumber f,
     std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints) {
   const int dimensions = 3;
   std::vector<std::vector<double>> tmp(controlPoints->size());
@@ -116,7 +116,7 @@ void PipelineWriter::newControlPoints(
 }
 
 std::string PipelineWriter::insertFrame(const std::string &templatePath,
-                                        FrameIndex f) const {
+                                        FrameNumber f) const {
   return boost::replace_all_copy(templatePath, "<frameNumber>",
                                  std::to_string(f));
 }
@@ -124,7 +124,7 @@ std::string PipelineWriter::insertFrame(const std::string &templatePath,
 void PipelineWriter::newClusterChains(
     std::shared_ptr<const std::vector<ClusterChain>> chains) {
   for (auto cloudIt : _clouds) {
-    FrameIndex f = cloudIt.first;
+    FrameNumber f = cloudIt.first;
     PointCloud cloud = *cloudIt.second;
     for (size_t chainIndex = 0; chainIndex < chains->size(); ++chainIndex) {
       const ClusterChain &chain = (*chains)[chainIndex];

--- a/app/pipeline_writer.h
+++ b/app/pipeline_writer.h
@@ -14,22 +14,22 @@ namespace MouseTrack {
 class PipelineWriter : public PipelineObserver {
 public:
   PipelineWriter(fs::path targetDir);
-  virtual void newRawPointCloud(FrameIndex f,
+  virtual void newRawPointCloud(FrameNumber f,
                                 std::shared_ptr<const PointCloud> cloud);
-  virtual void newFilteredPointCloud(FrameIndex f,
+  virtual void newFilteredPointCloud(FrameNumber f,
                                      std::shared_ptr<const PointCloud> cloud);
   virtual void
-  newClusters(FrameIndex f,
+  newClusters(FrameNumber f,
               std::shared_ptr<const std::vector<Cluster>> clusters);
   virtual void newDescriptors(
-      FrameIndex f,
+      FrameNumber f,
       std::shared_ptr<
           const std::vector<std::shared_ptr<const ClusterDescriptor>>>
           descriptors);
-  virtual void newMatches(FrameIndex f,
+  virtual void newMatches(FrameNumber f,
                           std::shared_ptr<const std::vector<long>> matches);
   virtual void newControlPoints(
-      FrameIndex f,
+      FrameNumber f,
       std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints);
 
   virtual void
@@ -45,11 +45,11 @@ private:
   std::string _matchesPath;
   std::string _controlPointsPath;
   std::string _chainedPointCloudPath;
-  std::unordered_map<FrameIndex, std::shared_ptr<const PointCloud>> _clouds;
-  std::unordered_map<FrameIndex, std::shared_ptr<const std::vector<Cluster>>>
+  std::unordered_map<FrameNumber, std::shared_ptr<const PointCloud>> _clouds;
+  std::unordered_map<FrameNumber, std::shared_ptr<const std::vector<Cluster>>>
       _clusters;
 
-  std::string insertFrame(const std::string &templatePath, FrameIndex f) const;
+  std::string insertFrame(const std::string &templatePath, FrameNumber f) const;
 
   /// index in [0, totalClusters)
   Eigen::Vector3d colorForCluster(int clusterIndex, int totalClusters) const;


### PR DESCRIPTION
# Delegate

Since we have quite some parameters to tweak, we might want to process the same frame repeatedly in an interactive fashion using the gui. This might require fine grained control. 

A delegate is an object that is called by another object (our pipeline) and asked different questions. For example: "which frame should the pipeline process next?" or "is there a frame remaining we should process?". Hence a delegate is a very suitable candidate to implement this desired fine grained control.

This will also allow us in the future to skip steps and add caching.

If no delegate is set, the Reader is used directly to acquire frames. Future methods probably should provide simple default implementations.

# Clean up

I noticed, there's an old typedef "FrameIndex" hanging around, which we didn't remove after a merge. I deprecated it and cleaned the current code.