### PR TITLE
Feature/fs/robust reader

### DIFF
--- a/app/matlab_reader.cpp
+++ b/app/matlab_reader.cpp
@@ -408,7 +408,14 @@ DisparityMap MatlabReader::readNormalizedDisparityMap(StreamNumber s,
   const auto candidatesPtr =
       _files.frames.find(ElementKey(s, f, NORMALIZED_DISPARITY_KEY));
   if (candidatesPtr == _files.frames.end()) {
-    throw "No file found.";
+    if (_normalizedDisparityRequired) {
+      BOOST_LOG_TRIVIAL(info)
+          << "No normalized disparity map file found for frame " << f
+          << " and stream " << s;
+      throw "No normalized disparity map file found.";
+    }
+    // return empty map
+    return DisparityMap{};
   }
   fs::path p = chooseCandidate(candidatesPtr->second);
   BOOST_LOG_TRIVIAL(trace) << "readNormalizedDisparityMap: " << p.string();
@@ -423,7 +430,13 @@ DisparityMap MatlabReader::readRawDisparityMap(StreamNumber s,
   const auto candidatesPtr =
       _files.frames.find(ElementKey(s, f, RAW_DISPARITY_KEY));
   if (candidatesPtr == _files.frames.end()) {
-    throw "No file found.";
+    if (_rawDisparityRequired) {
+      BOOST_LOG_TRIVIAL(info) << "No raw disparity map file found for frame "
+                              << f << " and stream " << s;
+      throw "No raw disparity map file found.";
+    }
+    // return empty map
+    return DisparityMap{};
   }
   fs::path p = chooseCandidate(candidatesPtr->second);
   BOOST_LOG_TRIVIAL(trace) << "readRawDisparityMap: " << p.string();
@@ -437,7 +450,12 @@ Eigen::MatrixXd MatlabReader::readChannelParameters(FrameNumber f) const {
   const auto candidatesPtr =
       _files.frames.find(ElementKey(-1, f, FRAME_PARAMETERS_KEY));
   if (candidatesPtr == _files.frames.end()) {
-    throw "No file found.";
+    if (_frameParametersRequired) {
+      BOOST_LOG_TRIVIAL(info)
+          << "No channel parameters file found for frame " << f;
+      throw "No channel paramters file found.";
+    }
+    return Eigen::MatrixXd{};
   }
   fs::path p = chooseCandidate(candidatesPtr->second);
   BOOST_LOG_TRIVIAL(trace) << "readChannelParameters: " << p.string();
@@ -449,7 +467,12 @@ Picture MatlabReader::readPicture(StreamNumber s, FrameNumber f) const {
   const auto candidatesPtr =
       _files.frames.find(ElementKey(s, f, REFERENCE_PICTURE_KEY));
   if (candidatesPtr == _files.frames.end()) {
-    throw "No file found.";
+    if (_referencePictureRequired) {
+      BOOST_LOG_TRIVIAL(info) << "No reference picture file found for frame "
+                              << f << " and stream " << s;
+      throw "No reference picture file found.";
+    }
+    return Picture{};
   }
   fs::path p = chooseCandidate(candidatesPtr->second);
   BOOST_LOG_TRIVIAL(trace) << "readPicture: " << p.string();

--- a/app/matlab_reader.cpp
+++ b/app/matlab_reader.cpp
@@ -319,6 +319,13 @@ FrameNumber MatlabReader::beginFrame() const { return _beginFrame; }
 
 FrameNumber MatlabReader::endFrame() const { return _endFrame; }
 
+void MatlabReader::setBeginFrame(FrameNumber f) {
+  _beginFrame = f;
+  _activeFrame = _completeFrameNumbers.lower_bound(f);
+}
+
+void MatlabReader::setEndFrame(FrameNumber f) { _endFrame = f; }
+
 FrameNumber MatlabReader::nextFrame() {
   if (_activeFrame == _completeFrameNumbers.end()) {
     return endFrame();
@@ -331,9 +338,6 @@ bool MatlabReader::hasNextFrame() const {
   return _activeFrame != _completeFrameNumbers.end() &&
          *_activeFrame < endFrame();
 }
-void MatlabReader::setBeginFrame(FrameNumber f) { _beginFrame = f; }
-
-void MatlabReader::setEndFrame(FrameNumber f) { _endFrame = f; }
 
 const std::vector<fs::path> &MatlabReader::ignoredPaths() const {
   return _ignoredPaths;

--- a/app/matlab_reader.h
+++ b/app/matlab_reader.h
@@ -25,6 +25,9 @@ public:
   /// directory
   MatlabReader(fs::path root_directory);
 
+  /// Default constructor
+  MatlabReader();
+
   /// true if constructor decided, the file system is formatted properly, false
   /// otherwise
   virtual bool valid() const;
@@ -46,6 +49,11 @@ public:
 
   /// Index of first non existing frame at the end
   virtual FrameNumber endFrame() const;
+
+  /// Return next frame number and increment internal pointer to next frame
+  virtual FrameNumber nextFrame();
+
+  virtual bool hasNextFrame() const;
 
   /// Increase lower bound of frame range.
   void setBeginFrame(FrameNumber f);
@@ -145,6 +153,17 @@ private:
   /// We collect expected paths here
   FilePaths _files;
 
+  /// All indexes we've seen (corresponding frames might not be complete)
+  std::set<FrameNumber> _seenFrameNumbers;
+
+  /// Indexes of all complete frames (all required data available)
+  std::set<FrameNumber> _completeFrameNumbers;
+
+  /// Points to the next active valid frame number starting at the lowest one.
+  /// If all frames are consumed, it points to the end of
+  /// `_completeFrameNumbers`.
+  std::set<FrameNumber>::iterator _activeFrame;
+
   /// Some files are expected to be accessed many times, we cache them here
   ConstParameters _cache;
   /// number of symlinks to evaluate (0: don't follow symlinks, 1: evaluate one
@@ -185,6 +204,9 @@ private:
   /// If there are multiple files mapping to the same key, this method tries to
   /// work out the best match
   fs::path chooseCandidate(const std::set<fs::path> &candidates) const;
+
+  /// Check if file exists
+  bool fileExists(const ElementKey &key) const;
 };
 
 } // namespace MouseTrack

--- a/app/matlab_reader.h
+++ b/app/matlab_reader.h
@@ -55,7 +55,8 @@ public:
 
   virtual bool hasNextFrame() const;
 
-  /// Increase lower bound of frame range.
+  /// Increase lower bound of frame range. Also sets the active frame for
+  /// FrameIterable to the first existing frame larger/equal to `f`
   void setBeginFrame(FrameNumber f);
 
   /// Lower upper bound of frame range.

--- a/app/matlab_reader.h
+++ b/app/matlab_reader.h
@@ -166,9 +166,26 @@ private:
 
   /// Some files are expected to be accessed many times, we cache them here
   ConstParameters _cache;
+
   /// number of symlinks to evaluate (0: don't follow symlinks, 1: evaluate one
   /// link, etc.)
   int _followSymlinkDepth = 1000;
+
+  /// if true: fail if no disparity map file is available
+  /// if false: set empty map
+  bool _normalizedDisparityRequired = true;
+
+  /// if true: fail if no disparity map file is available
+  /// if false: set empty map
+  bool _rawDisparityRequired = false;
+
+  /// if true: fail if no parameters file is available
+  /// if false: set empty parameters
+  bool _frameParametersRequired = true;
+
+  /// if true: fail if no reference picture file is available
+  /// if false: set empty reference picture
+  bool _referencePictureRequired = true;
 
   /// Assumes an existing `_root` directory. It scans the directory and collects
   /// all filenames that might interest us.

--- a/app/pipeline.cpp
+++ b/app/pipeline.cpp
@@ -204,7 +204,8 @@ void Pipeline::runPipeline() {
     }
   } else {
     // no delegate set, fall back to reader
-    for (FrameNumber f = _reader->beginFrame(); f < _reader->endFrame(); ++f) {
+    while (_reader->hasNextFrame()) {
+      FrameNumber f = _reader->nextFrame();
       if (terminateEarly()) {
         break;
       }

--- a/app/pipeline_delegate.h
+++ b/app/pipeline_delegate.h
@@ -5,21 +5,14 @@
 #pragma once
 
 #include "generic/types.h"
+#include "reader/frame_iterable.h"
 
 namespace MouseTrack {
 
 /// Implement this interface if you want to control the pipeline
 /// at run time in an interactive manner.
-class PipelineDelegate {
+class PipelineDelegate : public FrameIterable {
 public:
   virtual ~PipelineDelegate() = default;
-
-  /// `true` if there exists a frame to process.
-  /// `false` if no more frames are available.
-  virtual bool hasNextFrame() const = 0;
-
-  /// Returns the frame number that should be processed
-  /// in the next run of the pipeline
-  virtual FrameNumber nextFrame() = 0;
 };
 } // namespace MouseTrack

--- a/lib/reader/frame_iterable.h
+++ b/lib/reader/frame_iterable.h
@@ -1,0 +1,28 @@
+/// \file
+/// Maintainer: Felice Serena
+///
+
+#pragma once
+
+#include "generic/types.h"
+
+namespace MouseTrack {
+
+class FrameIterable {
+public:
+  ~FrameIterable() = default;
+
+  /// Is another frame available to process?
+  ///
+  /// `true` if there exists a frame to process.
+  ///
+  /// `false` if no more frames are available.
+  virtual bool hasNextFrame() const = 0;
+
+  /// Return the next frame number to process (f_i and f_{i+1} could be
+  /// non-sequential: f_{i+1} - f_i > 1) If nextFrame() == endFrame(), there are
+  /// no more frames available.
+  virtual FrameNumber nextFrame() = 0;
+};
+
+} // namespace MouseTrack

--- a/lib/reader/reader.h
+++ b/lib/reader/reader.h
@@ -4,22 +4,16 @@
 
 #pragma once
 
+#include "frame_iterable.h"
 #include "generic/disparity_map.h"
 #include "generic/frame_window.h"
-#include "generic/types.h"
 
 namespace MouseTrack {
 
-class Reader {
+class Reader : public FrameIterable {
 public:
   /// true if the reader is ready to provide output
   virtual bool valid() const = 0;
-
-  /// index of first existing frame
-  virtual FrameNumber beginFrame() const = 0;
-
-  /// Index of first non existing frame at the end
-  virtual FrameNumber endFrame() const = 0;
 
   /// Creates the Frame Window for frame index f, might read from disk/network
   /// This method is allowed to change the result of `endFrame`, if new frames

--- a/scripts/config_example.m
+++ b/scripts/config_example.m
@@ -25,6 +25,9 @@ startFrame = 1;
 % if maxProcessFrames = 0: only startFrame will be processed
 maxProcessFrames = 1000000000; 
 
+% Export raw disparity maps that include debug values and aren't scaled?
+export_raw_disparity = false;
+
 % does not overwrite complete frames on disk (but overwrites all files, if
 % some are missing)
 use_cache = true;

--- a/scripts/extract_camera_streams.m
+++ b/scripts/extract_camera_streams.m
@@ -98,24 +98,26 @@ msg = readMessages(img_streams(1), 1);
 pic1 = readImage(msg{1});
 [h, w] = size(pic1);
 
-% preallocate
-out_pics = cell(streams, 1);
-out_depths = cell(streams, 1);
-out_depthsCleaned = cell(streams, 1);
-out_ptCloud = cell(streams, 1);
-pics = cell(streams, 1);
-depths = cell(streams, 1);
-depthsCleaned = cell(streams, 1);
-focallengths = zeros(streams, 1);
-baselines = zeros(streams, 1);
-ccx = zeros(streams, 1);
-ccy = zeros(streams, 1);
-% initialize point clouds
-xyzPoints = cell(streams, 1);
+endIndex = min(lowestIndex, startFrame + maxProcessFrames-1);
 
-endIndex = min(highestIndex, startFrame + maxProcessFrames);
+fprintf('start: %d, last: %d\n', startFrame, endIndex);
 
 for image_index = startFrame:endIndex
+    % preallocate
+    out_pics = cell(streams, 1);
+    out_depths = cell(streams, 1);
+    out_depthsCleaned = cell(streams, 1);
+    out_ptCloud = cell(streams, 1);
+    pics = cell(streams, 1);
+    depths = cell(streams, 1);
+    depthsCleaned = cell(streams, 1);
+    focallengths = zeros(streams, 1);
+    baselines = zeros(streams, 1);
+    ccx = zeros(streams, 1);
+    ccy = zeros(streams, 1);
+    % initialize point clouds
+    xyzPoints = cell(streams, 1);
+
     progress = ['Extracting: ' int2str(image_index) '/' int2str(lowestIndex) ];
     fprintf(progress);
     
@@ -135,7 +137,7 @@ for image_index = startFrame:endIndex
     skip = exist(out_frame_params, 'file') && (exist(out_ptCloudTotal, 'file') || ~extract_point_clouds);
     for i = 1:streams
         if  ~exist(out_pics{i}, 'file') ...
-            || ~exist(out_depths{i}, 'file') ...
+            || (export_raw_disparity && ~exist(out_depths{i}, 'file')) ...
             || ~exist(out_depthsCleaned{i}, 'file') ...
             || (~exist(out_ptCloud{i}, 'file') && extract_point_clouds)
             skip = false;
@@ -186,7 +188,9 @@ for image_index = startFrame:endIndex
             continue;
         end
         imwrite(pics{i}, out_pics{i});
-        imwrite(depths{i}, out_depths{i});
+        if export_raw_disparity
+            imwrite(depths{i}, out_depths{i});
+        end
         cleaned = uint8(depthsCleaned{i});
         imwrite(cleaned, out_depthsCleaned{i});
     end


### PR DESCRIPTION
As discussed, I've adjusted the MatlabReader such that it skips frames that aren't around/complete (no warning printed ... desirable?). For this, a Reader now supports the same `hasNextFrame()/nextFrame()` mechanism as the pipelineDelegate. I've moved the declarations into a new `FrameIterable` interface (I hope to be able to unify the calls one day and get rid of the branching within the pipeline ...).

I've also changed the extraction script such that the raw disparity map no longer is exported, we don't use it anyway (you need to add the corresponding value in your config of the script). I've also moved the preallocation stuff inside the for loop by default. This way we are more flexible to play around with parallelization of the extraction.

