### PR TITLE
pipeline-timer can write times to output

### DIFF
--- a/app/cli_options.cpp
+++ b/app/cli_options.cpp
@@ -17,6 +17,7 @@ op::options_description cli_options() {
   ad("out-dir,o", op::value<std::string>(), "Target directory for computed results. No results will be written, if not provided.");
   ad("cli,c", "Don't start the Graphical User Interface, run on command line.");
   ad("pipeline-timer", "Measures the execution time of each pipeline step end sends it's output to the log with debug priority.");
+  ad("pipeline-timer-log", op::value<std::string>(), "If set, the pipeline times will be written to this file in csv format. (frame number, total frame time, READ_FRAME_WINDOW,FRAME_WINDOW_FILTERING,REGISTRATION,POINT_CLOUD_FILTERING,CLUSTERING,DESCRIPTING,MATCHING,CONTROL_POINTS)");
   ad("log,l", op::value<std::string>()->default_value("info"), "Set lowest log level to show. Possible options: trace, debug, info, warning, error, fatal, none. Default: info");
   ad("first-frame", op::value<int>(), "Desired lowest start frame (inclusive).");
   ad("last-frame", op::value<int>(), "Desired highest end frame (inclusive).");

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -131,6 +131,10 @@ int main(int argc, char *argv[]) {
   try {
     controller->pipeline() =
         std::move(pipelineFactory.fromCliOptions(cli_options));
+    if (cli_options.count("pipeline-timer-log")) {
+      std::string p = cli_options["pipeline-timer-log"].as<std::string>();
+      timer.logPath(p);
+    }
     if (cli_options.count("pipeline-timer")) {
       controller->pipeline().addObserver(&timer);
     }

--- a/app/pipeline_timer.h
+++ b/app/pipeline_timer.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "pipeline_observer.h"
+
 #include <chrono>
+#include <fstream>
 
 namespace MouseTrack {
 
@@ -57,11 +59,19 @@ public:
       FrameNumber f,
       std::shared_ptr<const std::vector<Eigen::Vector3d>> controlPoints);
 
+  /// Output file path to write times in csv format, set to empty string if not
+  /// desired
+  void logPath(const std::string &logPath);
+  const std::string &logPath() const;
+
 private:
   typedef std::pair<FrameNumber, std::string> Key;
   void startTimer(FrameNumber f, const std::string &key);
   void stopTimer(FrameNumber f, const std::string &key);
   std::map<Key, std::chrono::system_clock::time_point> _starts;
+  std::map<FrameNumber, std::map<std::string, int>> _durations;
+  std::string _logPath;
+  std::ofstream _logFileHandle;
 };
 
 } // namespace MouseTrack


### PR DESCRIPTION
Writes the times acquired by PipelineWriter to disk if `--pipeline-writer-log=<path>` is set. 

Times are in microseconds, one line per frame, columns: as defined by `moustrack --help` (Frame number, total time for frame, <modules>).