### PR TITLE
Feature/fs/spatial refac

### DIFF
--- a/lib/classifier/classifier.h
+++ b/lib/classifier/classifier.h
@@ -12,7 +12,8 @@ namespace MouseTrack {
 /// Interface for classification algorithms.
 class Classifier {
 public:
-  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
+  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic,
+                        Eigen::ColMajor + Eigen::AutoAlign>
       Mat;
 
   typedef Eigen::VectorXi Vec;

--- a/lib/classifier/knn.cpp
+++ b/lib/classifier/knn.cpp
@@ -35,10 +35,10 @@ void KnnClassifier::fit(const Mat &X_train, const Vec &y_train) {
 KnnClassifier::Vec KnnClassifier::predict(const Mat &X_test) const {
   Vec result, tmpAgg;
   result.resize(X_test.cols());
+  auto closest = _oracle->find_closest(X_test, _k);
   for (int i = 0; i < X_test.cols(); ++i) {
     tmpAgg.setZero(_highestLabel + 1);
-    auto closest = _oracle->find_closest(X_test.col(i), _k);
-    for (auto c : closest) {
+    for (auto c : closest[i]) {
       int l = _y_train[c];
       tmpAgg[l] += 1;
     }
@@ -51,9 +51,9 @@ KnnClassifier::Mat
 KnnClassifier::predictProbabilities(const Mat &X_test) const {
   Eigen::MatrixXd result;
   result.setZero(_highestLabel + 1, X_test.cols());
+  auto closest = _oracle->find_closest(X_test, _k);
   for (int i = 0; i < X_test.cols(); ++i) {
-    auto closest = _oracle->find_closest(X_test.col(i), _k);
-    for (auto c : closest) {
+    for (auto c : closest[i]) {
       int l = _y_train[c];
       result(l, i) += 1;
     }

--- a/lib/classifier/knn.h
+++ b/lib/classifier/knn.h
@@ -14,7 +14,7 @@ namespace MouseTrack {
 
 class KnnClassifier : public Classifier {
 public:
-  typedef SpatialOracle<Mat, Eigen::VectorXd, double> Oracle;
+  typedef SpatialOracle<Mat, double> Oracle;
   typedef OracleFactory<Precision, -1> OFactory;
 
   KnnClassifier();

--- a/lib/clustering/kmeans.cpp
+++ b/lib/clustering/kmeans.cpp
@@ -65,11 +65,10 @@ std::vector<Cluster> KMeans::operator()(const PointCloud &cloud) const {
     oracle.compute(means);
     prevClusters = std::move(clusters);
     clusters = std::vector<Cluster>(K());
-
+    std::vector<std::vector<PointIndex>> allCs = oracle.find_closest(points, 1);
     for (int i = 0; i < points.cols(); ++i) {
-      std::vector<size_t> cs = oracle.find_closest(points.col(i), 1);
+      auto &cs = allCs[i];
       if (cs.empty()) {
-        oracle.find_closest(points.col(i), 1);
         BOOST_LOG_TRIVIAL(error)
             << "Couldn't find nearest mean for point " << i << " ("
             << points.col(i) << "), assigning to 1";

--- a/lib/clustering/kmeans.h
+++ b/lib/clustering/kmeans.h
@@ -15,10 +15,9 @@
 namespace MouseTrack {
 class KMeans : public Clustering {
 public:
-  typedef OracleFactory<double> OFactory;
+  typedef OracleFactory<Precision> OFactory;
   typedef OFactory::Oracle Oracle;
   typedef Oracle::PointList PointList;
-  typedef Oracle::Point Point;
 
   KMeans(int k);
 

--- a/lib/clustering/mean_shift.cpp
+++ b/lib/clustering/mean_shift.cpp
@@ -91,7 +91,7 @@ MeanShift::convergePoints(const Oracle::PointList &points) const {
       // perform one iteration of mean shift
       prevCenter = currCenters[i];
       std::vector<PointIndex> locals =
-          oracle.find_in_range(currCenters[i], 2 * _window_size);
+          oracle.find_in_range(currCenters[i], 2 * _window_size)[0];
       if (locals.empty()) {
         BOOST_LOG_TRIVIAL(warning)
             << "No points in neighborhood, falling back to brute force.";

--- a/lib/clustering/mean_shift_cpu_optimized.cpp
+++ b/lib/clustering/mean_shift_cpu_optimized.cpp
@@ -51,7 +51,7 @@ MeanShiftCpuOptimized::convergePoints(const Oracle::PointList &points) const {
       // perform one iteration of mean shift
       prevCenter = currCenters[i];
       std::vector<PointIndex> locals =
-          oracle.find_in_range(currCenters[i], 2 * getWindowSize());
+          oracle.find_in_range(currCenters[i], 2 * getWindowSize())[0];
       if (locals.empty()) {
         BOOST_LOG_TRIVIAL(warning)
             << "No points in neighborhood, falling back to brute force.";
@@ -106,7 +106,7 @@ std::vector<Cluster> MeanShiftCpuOptimized::mergePoints(
   // pick first point and ask spatial oracle for it's neighbors within the merge
   // threshold and create a new cluster from it.
   //
-  // Removed the clustered points from `remainingPoints` and repeat
+  // Remove the clustered points from `remainingPoints` and repeat
   while (!remainingPoints.empty()) {
     Oracle::PointList points(dimensions, remainingPoints.size());
 
@@ -116,7 +116,7 @@ std::vector<Cluster> MeanShiftCpuOptimized::mergePoints(
 
     mergeOracle.compute(points);
     auto neighbors = mergeOracle.find_in_range(currCenters[remainingPoints[0]],
-                                               getMergeThreshold());
+                                               getMergeThreshold())[0];
     // erase_indices assumes a sorted index vector
     std::sort(neighbors.begin(), neighbors.end());
 

--- a/lib/point_cloud_filtering/statistical_outlier_removal.cpp
+++ b/lib/point_cloud_filtering/statistical_outlier_removal.cpp
@@ -26,7 +26,6 @@ operator()(const PointCloud &inCloud) const {
   UniformGrid3d ug(bb_size.maxCoeff(), bb_size.minCoeff() / 50.0);
 
   typedef UniformGrid3d::PointList PointList;
-  typedef UniformGrid3d::Point Point;
   PointList pts(3, inCloud.size());
   for (size_t i = 0; i < inCloud.size(); ++i) {
     auto p = inCloud[i];
@@ -35,8 +34,8 @@ operator()(const PointCloud &inCloud) const {
     pts(2, i) = p.x();
   }
   ug.compute(pts);
-  auto outliers = statisticalOutlierDetection<PointList, Point, Precision>(
-      pts, &ug, alpha(), k());
+  auto outliers =
+      statisticalOutlierDetection<PointList, Precision>(pts, &ug, alpha(), k());
 
   PointCloud outCloud;
   outCloud.resize(inCloud.size() - outliers.size(), inCloud.labelsDim());

--- a/lib/spatial/brute_force.h
+++ b/lib/spatial/brute_force.h
@@ -19,35 +19,19 @@ namespace MouseTrack {
 template <typename _Precision, int _Dim>
 class BruteForce
     : public SpatialOracle<Eigen::Matrix<_Precision, _Dim, Eigen::Dynamic,
-                                         Eigen::RowMajor + Eigen::AutoAlign>,
-                           Eigen::Matrix<_Precision, _Dim, 1>, _Precision> {
+                                         Eigen::ColMajor + Eigen::AutoAlign>,
+                           _Precision> {
 public:
   typedef Eigen::Matrix<_Precision, _Dim, Eigen::Dynamic,
-                        Eigen::RowMajor + Eigen::AutoAlign>
+                        Eigen::ColMajor + Eigen::AutoAlign>
       PointList;
-  typedef Eigen::Matrix<_Precision, _Dim, 1> Point;
 
 private:
   const PointList *_points = nullptr;
 
-public:
-  BruteForce() {
-    // empty
-  }
-
-  void compute(const PointList &points) { _points = &points; }
-
-  virtual PointIndex find_closest(const Point &p) const {
-    assert(_points != nullptr);
-    PointIndex nearestP;
-    (_points->colwise() - p).colwise().squaredNorm().minCoeff(&nearestP);
-    return nearestP;
-  }
-
-  virtual std::vector<PointIndex> find_closest(const Point &p,
-                                               unsigned int k) const {
-    assert(_points != nullptr);
-    assert(k >= 1);
+  template <typename Point>
+  std::vector<PointIndex> find_closest_for_point(const Point &p,
+                                                 unsigned int k) const {
     typedef std::pair<Precision, PointIndex> P;
     std::priority_queue<P> candidates;
     auto dists = (_points->colwise() - p).colwise().squaredNorm();
@@ -66,17 +50,48 @@ public:
     return result;
   }
 
-  virtual std::vector<PointIndex> find_in_range(const Point &p,
-                                                const Precision r) const {
-    assert(_points != nullptr);
+  template <typename Point>
+  std::vector<PointIndex> find_in_range_for_point(const Point &p,
+                                                  const Precision r) const {
     std::vector<PointIndex> in_range;
     Precision r2 = r * r;
-    auto dists = (_points->colwise() - p).colwise().squaredNorm();
+    auto diffs = _points->colwise() - p;
+    auto dists = diffs.colwise().squaredNorm();
     for (int i = 0; i < dists.cols(); i += 1) {
       Precision d = dists(0, i);
       if (d < r2) {
         in_range.push_back(i);
       }
+    }
+    return in_range;
+  }
+
+public:
+  BruteForce() {
+    // empty
+  }
+
+  void compute(const PointList &points) { _points = &points; }
+
+  virtual std::vector<std::vector<PointIndex>>
+  find_closest(const PointList &ps, unsigned int k) const {
+    assert(_points != nullptr);
+    assert(k >= 1);
+    std::vector<std::vector<PointIndex>> result;
+    result.reserve(ps.size());
+    for (int c = 0; c < ps.cols(); ++c) {
+      result.push_back(find_closest_for_point(ps.col(c), k));
+    }
+    return result;
+  }
+
+  virtual std::vector<std::vector<PointIndex>>
+  find_in_range(const PointList &ps, const Precision r) const {
+    assert(_points != nullptr);
+    std::vector<std::vector<PointIndex>> in_range;
+    in_range.reserve(ps.cols());
+    for (int c = 0; c < ps.cols(); ++c) {
+      in_range.push_back(find_in_range_for_point(ps.col(c).eval(), r));
     }
     return in_range;
   }

--- a/lib/spatial/brute_force.test.cc
+++ b/lib/spatial/brute_force.test.cc
@@ -26,22 +26,40 @@ BOOST_AUTO_TEST_CASE(brute_force_4d_in_range) {
   all.col(3) = Vector4d(0.0, -1.0, -1.0, -1.0);
   all.col(4) = Vector4d(10.0, 1.0, 1.0, 1.0);
 
-  std::set<PointIndex> expected;
-  expected.insert(2);
-  expected.insert(4);
+  std::set<PointIndex> expected0;
+  expected0.insert(2);
+  expected0.insert(4);
+
+  std::set<PointIndex> expected1;
+  expected1.insert(0);
+  expected1.insert(3);
 
   BF oracle;
   oracle.compute(all);
 
-  auto result = oracle.find_in_range(Vector4d(9.5, 0, 0, 0), 2);
+  Eigen::Matrix<double, 4, -1> query(4, 2);
+  query.col(0) = Vector4d(9.5, 0, 0, 0);
+  query.col(1) = Vector4d(0.0, -0.5, -0.5, -0.5);
 
-  std::set<PointIndex> received(result.begin(), result.end());
+  auto result = oracle.find_in_range(query, 2);
+
+  std::set<PointIndex> received0(result[0].begin(), result[0].end());
+  std::set<PointIndex> received1(result[1].begin(), result[1].end());
+
+  BOOST_CHECK_EQUAL(result.size(), 2);
 
   BOOST_CHECK_MESSAGE(
-      expected.size() == received.size(),
+      expected0.size() == received0.size(),
       "Expected and received sets have different cardinalities.");
   BOOST_CHECK_MESSAGE(
-      expected == received,
+      expected0 == received0,
+      "Expected and received set do not contain same elements.");
+
+  BOOST_CHECK_MESSAGE(
+      expected1.size() == received1.size(),
+      "Expected and received sets have different cardinalities.");
+  BOOST_CHECK_MESSAGE(
+      expected1 == received1,
       "Expected and received set do not contain same elements.");
 }
 
@@ -62,7 +80,7 @@ BOOST_AUTO_TEST_CASE(brute_force_Xd_in_range) {
   BF oracle;
   oracle.compute(all);
 
-  auto result = oracle.find_in_range(Vector4d(9.5, 0, 0, 0), 2);
+  auto result = oracle.find_in_range(Vector4d(9.5, 0, 0, 0), 2)[0];
 
   std::multiset<PointIndex> received(result.begin(), result.end());
 
@@ -87,11 +105,22 @@ BOOST_AUTO_TEST_CASE(brute_force_Xd_find_closest) {
   BF oracle;
   oracle.compute(all);
 
-  std::vector<size_t> expected;
-  expected.push_back(4);
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 1);
-  BOOST_CHECK_EQUAL(expected.size(), result.size());
-  BOOST_CHECK_EQUAL(expected[0], result[0]);
+  std::vector<size_t> expected0;
+  expected0.push_back(4);
+
+  std::vector<size_t> expected1;
+  expected1.push_back(0);
+
+  Eigen::MatrixXd query(4, 2);
+  query.col(0) = Vector4d(10.1, 0.9, 0.9, 0.9);
+  query.col(1) = Vector4d(0.1, 0.1, 0.1, 0.1);
+
+  auto result = oracle.find_closest(query, 1);
+  BOOST_CHECK_EQUAL(expected1.size(), result[0].size());
+  BOOST_CHECK_EQUAL(expected0[0], result[0][0]);
+
+  BOOST_CHECK_EQUAL(expected1.size(), result[1].size());
+  BOOST_CHECK_EQUAL(expected1[0], result[1][0]);
 }
 
 BOOST_AUTO_TEST_CASE(brute_force_Xd_find_closestK) {
@@ -111,7 +140,7 @@ BOOST_AUTO_TEST_CASE(brute_force_Xd_find_closestK) {
   BF oracle;
   oracle.compute(all);
 
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2);
+  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2)[0];
 
   std::multiset<PointIndex> received(result.begin(), result.end());
 

--- a/lib/spatial/flann.h
+++ b/lib/spatial/flann.h
@@ -15,37 +15,35 @@ namespace MouseTrack {
 template <typename _Precision, int _Dim>
 class Flann
     : public SpatialOracle<Eigen::Matrix<_Precision, _Dim, Eigen::Dynamic,
-                                         Eigen::RowMajor + Eigen::AutoAlign>,
-                           Eigen::Matrix<_Precision, _Dim, 1>, _Precision> {
+                                         Eigen::ColMajor + Eigen::AutoAlign>,
+                           _Precision> {
 public:
   // columns are points
   typedef Eigen::Matrix<_Precision, _Dim, Eigen::Dynamic,
-                        Eigen::RowMajor + Eigen::AutoAlign>
+                        Eigen::ColMajor + Eigen::AutoAlign>
       PointList;
-  typedef Eigen::Matrix<_Precision, _Dim, 1> Point;
   typedef _Precision Precision;
 
 private:
-  // rows are points
-  typedef Eigen::Matrix<_Precision, Eigen::Dynamic, _Dim,
-                        Eigen::RowMajor + Eigen::AutoAlign>
-      PointListT;
   // make sure to store one point per row for flann
-  PointListT _points;
+  const PointList *_points = nullptr;
   std::unique_ptr<flann::Index<flann::L2<Precision>>> _index;
   flann::Matrix<Precision> dataset;
 
+  const flann::Matrix<Precision> flannFrom(const PointList &ps) const {
+    // flann matrices expect row major data, where rows are samples and cols
+    // dimensions, we are responsible for the lifetime
+    const flann::Matrix<Precision> converted =
+        flann::Matrix<Precision>((Precision *)ps.data(), ps.cols(), ps.rows());
+    return converted;
+  }
+
 public:
   virtual void compute(const PointList &srcData) {
-    // transpose data: we get points as columns,
-    // but points must be rows for flann
-    _points = srcData.transpose();
-    // flann matrices expects row major data,
-    // we are responsible for the lifetime
-    dataset = flann::Matrix<Precision>(_points.data(), _points.rows(),
-                                       _points.cols());
+    _points = &srcData;
+    dataset = flannFrom(srcData);
     // choose exact implementation: this is a list of tried values
-    flann::IndexParams params = flann::KDTreeIndexParams(); // inacurate
+    flann::IndexParams params = flann::KDTreeIndexParams(); // inaccurate
     params = flann::LinearIndexParams();                    // slow
     params = flann::KDTreeSingleIndexParams(); // for low dimensional data
     params = flann::AutotunedIndexParams();    // auto tuning: target precision,
@@ -57,8 +55,8 @@ public:
     _index->buildIndex();
   }
 
-  virtual std::vector<PointIndex> find_closest(const Point &p,
-                                               unsigned int k) const {
+  virtual std::vector<std::vector<PointIndex>>
+  find_closest(const PointList &ps, unsigned int k) const {
     assert(k >= 1);
     // d: dimensions
     // k: desired nearest neighbors
@@ -66,31 +64,27 @@ public:
     std::vector<std::vector<PointIndex>> indices;
     std::vector<std::vector<Precision>> dists;
     // query
-    // query: 1xd point
-    // strip off const just for a moment
-    const flann::Matrix<Precision> query((Precision *)p.data(), 1, p.size());
+    const flann::Matrix<Precision> query = flannFrom(ps);
 
     // querying
     _index->knnSearch(query, indices, dists, k, flann::SearchParams(128));
 
-    return std::move(indices[0]);
+    return std::move(indices);
   }
 
-  virtual std::vector<PointIndex> find_in_range(const Point &p,
-                                                const Precision r) const {
+  virtual std::vector<std::vector<PointIndex>>
+  find_in_range(const PointList &ps, const Precision r) const {
     // d: dimensions
     std::vector<std::vector<PointIndex>> indices;
     std::vector<std::vector<Precision>> dists;
 
     // query
-    // query: 1xd point
-    // strip off const just for a moment
-    const flann::Matrix<Precision> query((Precision *)p.data(), 1, p.size());
+    const flann::Matrix<Precision> query = flannFrom(ps);
 
     // querying
     _index->radiusSearch(query, indices, dists, r, flann::SearchParams(128));
 
-    return std::move(indices[0]);
+    return std::move(indices);
   }
 };
 

--- a/lib/spatial/flann.h
+++ b/lib/spatial/flann.h
@@ -67,7 +67,10 @@ public:
     const flann::Matrix<Precision> query = flannFrom(ps);
 
     // querying
-    _index->knnSearch(query, indices, dists, k, flann::SearchParams(128));
+    auto params = flann::SearchParams(128);
+    // automatically parallelize
+    params.cores = 0;
+    _index->knnSearch(query, indices, dists, k, params);
 
     return std::move(indices);
   }
@@ -82,7 +85,10 @@ public:
     const flann::Matrix<Precision> query = flannFrom(ps);
 
     // querying
-    _index->radiusSearch(query, indices, dists, r, flann::SearchParams(128));
+    auto params = flann::SearchParams(128);
+    // automatically parallelize
+    params.cores = 0;
+    _index->radiusSearch(query, indices, dists, r, params);
 
     return std::move(indices);
   }

--- a/lib/spatial/flann.test.cc
+++ b/lib/spatial/flann.test.cc
@@ -26,17 +26,29 @@ BOOST_AUTO_TEST_CASE(flann_4d_two_close_points_find_in_range) {
   Oracle oracle;
   oracle.compute(all);
 
-  std::multiset<PointIndex> expected;
+  std::multiset<PointIndex> expected0;
+  expected0.insert(0);
+  expected0.insert(1);
 
-  // first test
-  expected.insert(0);
-  expected.insert(1);
-  auto result = oracle.find_in_range(Vector4d(0.0, 0, 0, 0), 1.0);
-  std::multiset<PointIndex> received(result.begin(), result.end());
+  std::multiset<PointIndex> expected1;
+  expected1.insert(0);
+  expected1.insert(1);
 
-  BOOST_CHECK_EQUAL(expected.size(), received.size());
+  Eigen::Matrix<double, 4, 2> query;
+  query.col(0) = Vector4d(0.0, 0, 0, 0);
+  query.col(1) = Vector4d(0.1, 0.2, 0.3, 0);
+  auto result = oracle.find_in_range(query, 1.0);
+  std::multiset<PointIndex> received0(result[0].begin(), result[0].end());
+  std::multiset<PointIndex> received1(result[1].begin(), result[1].end());
+
+  BOOST_CHECK_EQUAL(expected0.size(), received0.size());
   BOOST_CHECK_MESSAGE(
-      expected == received,
+      expected0 == received0,
+      "Expected and received set do not contain same elements.");
+
+  BOOST_CHECK_EQUAL(expected1.size(), received1.size());
+  BOOST_CHECK_MESSAGE(
+      expected1 == received1,
       "Expected and received set do not contain same elements.");
 }
 
@@ -53,11 +65,22 @@ BOOST_AUTO_TEST_CASE(flann_Xd_find_closest) {
   Oracle oracle;
   oracle.compute(all);
 
-  std::vector<size_t> expected;
-  expected.push_back(4);
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 1);
-  BOOST_CHECK_EQUAL(expected.size(), result.size());
-  BOOST_CHECK_EQUAL(expected[0], result[0]);
+  std::vector<size_t> expected0;
+  expected0.push_back(4);
+  std::vector<size_t> expected1;
+  expected1.push_back(0);
+
+  Matrix<double, 4, 2> query;
+  query.col(0) = Vector4d(10.1, 0.9, 0.9, 0.9);
+  query.col(1) = Vector4d(0.1, 0.1, 0.1, 0.1);
+
+  auto result = oracle.find_closest(query, 1);
+
+  BOOST_CHECK_EQUAL(expected0.size(), result[0].size());
+  BOOST_CHECK_EQUAL(expected0[0], result[0][0]);
+
+  BOOST_CHECK_EQUAL(expected1.size(), result[1].size());
+  BOOST_CHECK_EQUAL(expected1[0], result[1][0]);
 }
 
 BOOST_AUTO_TEST_CASE(flann_Xd_find_closestK) {
@@ -77,7 +100,7 @@ BOOST_AUTO_TEST_CASE(flann_Xd_find_closestK) {
   Oracle oracle;
   oracle.compute(all);
 
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2);
+  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2)[0];
 
   std::multiset<PointIndex> received(result.begin(), result.end());
 

--- a/lib/spatial/oracle_factory.h
+++ b/lib/spatial/oracle_factory.h
@@ -40,11 +40,11 @@ public:
   void desiredOracle(Oracles oracle) { _desiredOracle = oracle; }
 
   typedef Eigen::Matrix<Precision, Dim, Eigen::Dynamic,
-                        Eigen::RowMajor + Eigen::AutoAlign>
+                        Eigen::ColMajor + Eigen::AutoAlign>
       PointList;
   typedef Eigen::Matrix<Precision, Dim, 1> Point;
 
-  typedef SpatialOracle<PointList, Point, Precision> Oracle;
+  typedef SpatialOracle<PointList, Precision> Oracle;
 
   struct Query {
     /// maximum range query you intend to perform

--- a/lib/spatial/spatial_oracle.h
+++ b/lib/spatial/spatial_oracle.h
@@ -13,18 +13,15 @@ namespace MouseTrack {
 /// proecesses and stores it internally, and allows the client
 /// to perform spatial queries.
 ///
-/// `PointList`: data type to communicate a batch of points.
-///
-/// `Point`: representation of points
+/// `PointList`:
 ///
 /// `Precision`: desired numerical precision (double, float)
-template <typename _PointList, typename _Point, typename _Precision>
-class SpatialOracle {
+template <typename _PointList, typename _Precision> class SpatialOracle {
 public:
-  /// Make available to client
+  /// Data type to communicate a batch of points. Columns are points,
+  /// rows are dimensions.
   typedef _PointList PointList;
-  /// Make available to client
-  typedef _Point Point;
+
   /// Make available to client
   typedef _Precision Precision;
 
@@ -37,13 +34,13 @@ public:
   virtual void compute(const PointList &points) = 0;
 
   /// Find `k` nearest points to `p`
-  virtual std::vector<PointIndex> find_closest(const Point &p,
-                                               unsigned int k = 1) const = 0;
+  virtual std::vector<std::vector<PointIndex>>
+  find_closest(const PointList &ps, unsigned int k = 1) const = 0;
 
   /// Give an index-list of all points within distance `r` around `p`
   /// The indexes are returned in random order.
-  virtual std::vector<PointIndex> find_in_range(const Point &p,
-                                                Precision r) const = 0;
+  virtual std::vector<std::vector<PointIndex>>
+  find_in_range(const PointList &ps, Precision r) const = 0;
 };
 
 } // namespace MouseTrack

--- a/lib/spatial/statistical_outlier_detection.test.cc
+++ b/lib/spatial/statistical_outlier_detection.test.cc
@@ -31,8 +31,8 @@ BOOST_AUTO_TEST_CASE(outlier_2d) {
   oracle.compute(all);
 
   std::vector<PointIndex> result =
-      statisticalOutlierDetection<UG::PointList, UG::Point, UG::Precision>(
-          all, &oracle, 2.0, 10);
+      statisticalOutlierDetection<UG::PointList, UG::Precision>(all, &oracle,
+                                                                2.0, 10);
 
   std::multiset<PointIndex> received(result.begin(), result.end());
 

--- a/lib/spatial/uniform_grid.test.cc
+++ b/lib/spatial/uniform_grid.test.cc
@@ -26,20 +26,33 @@ BOOST_AUTO_TEST_CASE(uniform_grid_4d) {
   all.col(3) = Vector4d(0.0, -1.0, -1.0, -1.0);
   all.col(4) = Vector4d(10.0, 1.0, 1.0, 1.0);
 
-  std::multiset<PointIndex> expected;
-  expected.insert(2);
-  expected.insert(4);
+  std::multiset<PointIndex> expected0;
+  expected0.insert(2);
+  expected0.insert(4);
+
+  std::multiset<PointIndex> expected1;
+  expected1.insert(0);
+  expected1.insert(3);
 
   UG oracle(2, 10.0 / 20);
   oracle.compute(all);
 
-  auto result = oracle.find_in_range(Vector4d(9.5, 0, 0, 0), 2);
+  Matrix<double, 4, 2> query;
+  query.col(0) = Vector4d(9.5, 0, 0, 0);
+  query.col(1) = Vector4d(0.1, 0.0, 0, 0);
+  auto result = oracle.find_in_range(query, 2);
 
-  std::multiset<PointIndex> received(result.begin(), result.end());
+  std::multiset<PointIndex> received0(result[0].begin(), result[0].end());
+  std::multiset<PointIndex> received1(result[1].begin(), result[1].end());
 
-  BOOST_CHECK_EQUAL(expected.size(), received.size());
+  BOOST_CHECK_EQUAL(expected0.size(), received0.size());
   BOOST_CHECK_MESSAGE(
-      expected == received,
+      expected0 == received0,
+      "Expected and received set do not contain same elements.");
+
+  BOOST_CHECK_EQUAL(expected1.size(), received1.size());
+  BOOST_CHECK_MESSAGE(
+      expected1 == received1,
       "Expected and received set do not contain same elements.");
 }
 
@@ -58,7 +71,7 @@ BOOST_AUTO_TEST_CASE(uniform_grid_4d_two_close_points) {
   // first test
   expected.insert(0);
   expected.insert(1);
-  auto result = oracle.find_in_range(Vector4d(0.0, 0, 0, 0), 1);
+  auto result = oracle.find_in_range(Vector4d(0.0, 0, 0, 0), 1)[0];
   std::multiset<PointIndex> received(result.begin(), result.end());
 
   BOOST_CHECK_EQUAL(expected.size(), received.size());
@@ -80,11 +93,22 @@ BOOST_AUTO_TEST_CASE(uniform_grid_Xd_find_closest) {
   UG oracle(2, 10.0 / 20);
   oracle.compute(all);
 
-  std::vector<size_t> expected;
-  expected.push_back(4);
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 1);
-  BOOST_CHECK_EQUAL(expected.size(), result.size());
-  BOOST_CHECK_EQUAL(expected[0], result[0]);
+  std::vector<size_t> expected0;
+  expected0.push_back(4);
+
+  std::vector<size_t> expected1;
+  expected1.push_back(0);
+
+  Matrix<double, 4, 2> query;
+  query.col(0) = Vector4d(10.1, 0.9, 0.9, 0.9);
+  query.col(1) = Vector4d(0.1, 0.1, 0.1, 0.1);
+
+  auto result = oracle.find_closest(query, 1);
+  BOOST_CHECK_EQUAL(expected0.size(), result[0].size());
+  BOOST_CHECK_EQUAL(expected0[0], result[0][0]);
+
+  BOOST_CHECK_EQUAL(expected1.size(), result[1].size());
+  BOOST_CHECK_EQUAL(expected1[0], result[1][0]);
 }
 
 BOOST_AUTO_TEST_CASE(uniform_grid_Xd_find_closestK) {
@@ -104,7 +128,7 @@ BOOST_AUTO_TEST_CASE(uniform_grid_Xd_find_closestK) {
   UG oracle(2, 10.0 / 20);
   oracle.compute(all);
 
-  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2);
+  auto result = oracle.find_closest(Vector4d(10.1, 0.9, 0.9, 0.9), 2)[0];
 
   std::multiset<PointIndex> received(result.begin(), result.end());
 


### PR DESCRIPTION
As announced, I've refactored the SpatialOracle interface: Instead of taking a single point, it now takes a batch of query points. This allows us to use FLANN's parallelization feature (implemented) and further optimizations for other objects are possible (Sorting points into cells and then only querying the cells could give a fairly descent speed up for the UniformGrid, but that's not implemented yet). 

Since it's an interface change, it touches quite some files. 