### PR TITLE
Fixed cog groundtruth reconstruction

### DIFF
--- a/scripts/extract_camera_streams.m
+++ b/scripts/extract_camera_streams.m
@@ -236,7 +236,7 @@ for image_index = startFrame:endIndex
                     xyzPoints{i}(y,x,2) = (y+yshift-ccy(i))/focallengths(i)*xyzPoints{i}(y,x,3);
 
                     %rotate/translate 3D points to cam rect reference frame
-                    temp = R{i}*T\[xyzPoints{i}(y,x,1),xyzPoints{i}(y,x,2),xyzPoints{i}(y,x,3),1 ]';
+                    temp = (R{i}*T)\[xyzPoints{i}(y,x,1),xyzPoints{i}(y,x,2),xyzPoints{i}(y,x,3),1 ]';
                     xyzPoints{i}(y,x,1) = temp(1);
                     xyzPoints{i}(y,x,2) = temp(2);
                     xyzPoints{i}(y,x,3) = temp(3);

--- a/scripts/projection_test.py
+++ b/scripts/projection_test.py
@@ -1,0 +1,52 @@
+import polygon2cog as p2c
+import validation as v
+import unittest
+import numpy as np
+
+
+class TestProjection(unittest.TestCase):
+    def assertIdentity(self, pt2d, c2w, params):
+        w2c = np.linalg.inv(c2w)
+        pt3d = p2c.register(pt2d, c2w, params)
+        pt2dd = v.project_point(np.array([pt3d]).T, w2c, params)
+        self.assertAlmostEqual(pt2d[0], pt2dd[0][0])
+        self.assertAlmostEqual(pt2d[1], pt2dd[1][0])
+    def test_minimum(self):
+        focallength = 1
+        ccx = 0
+        ccy = 0
+        params = [focallength, 0, ccx, ccy]
+        pt2d = np.array([0,0])
+        c2w = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+        self.assertIdentity(pt2d, c2w, params)
+    def test_random(self):
+        focallength = 2
+        ccx = 30
+        ccy = 40
+        params = [focallength, 0, ccx, ccy]
+        pt2d = np.array([-17,23])
+        c2w = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+        self.assertIdentity(pt2d, c2w, params)
+    def test_random(self):
+        focallength = 2
+        ccx = 30
+        ccy = 40
+        params = [focallength, 0, ccx, ccy]
+        pt2d = np.array([-17,23])
+        c2w = np.array([[1, 0, 0, 199], [0, 1, 0, -12], [0, 0, 1, 5], [0, 0, 0, 1]])
+        self.assertIdentity(pt2d, c2w, params)
+    def test_random_rotation(self):
+        focallength = 2
+        ccx = 30
+        ccy = 40
+        params = [focallength, 0, ccx, ccy]
+        pt2d = np.array([-17,23])
+        c2w = np.array([
+            [0.9106836, -0.2440169, 0.3333333, 199], 
+            [0.3333333, 0.9106836, -0.2440168, -12], 
+            [-0.2440169, 0.333333, 0.91068361, 5], 
+            [0, 0, 0, 1]])
+        self.assertIdentity(pt2d, c2w, params)
+
+if __name__ == '__main__':
+        unittest.main()

--- a/scripts/validation.py
+++ b/scripts/validation.py
@@ -53,6 +53,10 @@ def make_projection_matrix(camchain,R,cam):
     return np.asarray(matrix,dtype='float64')
 
 def project_point(control_point, projection_matrix, params):
+    """
+    Takes a 3 dimensional control point (np.array([[x,y,z]])), a 4x4 projection_matrix from world to camera, and 
+    params = [focallength, _, ccx, ccy]
+    """
     focallength = float(params[0])
     ccx = float(params[2])
     ccy = float(params[3])
@@ -63,6 +67,21 @@ def project_point(control_point, projection_matrix, params):
     cc = np.array([[ccx, ccy]]).T
     shift = np.array([[X_SHIFT,Y_SHIFT]]).T
     return p2D - shift + cc
+
+colors = [
+        (0, 0, 255), 
+        (0, 255, 0), 
+        (255, 0, 0), 
+        (255, 255, 0),
+        (255, 0, 255),
+        (0, 255, 255),
+        (255, 255, 255),
+        (0,0,0)
+        ]
+
+def point_color(i):
+    return colors[i % len(colors)]
+    
 
 if __name__ == "__main__":
 
@@ -121,11 +140,12 @@ if __name__ == "__main__":
                 continue
             pic = cv2.imread(png_file)
             projection_matrix = make_projection_matrix(camchain,R,stream)
-            for cp4 in cpoints: 
+            for ci in range(len(cpoints)): 
+                cp4 = cpoints[ci]
                 cp2 = project_point(cp4,projection_matrix,params[stream])
                 cp2 = cp2.astype(np.int32)
                 #Display control point in image
-                cv2.circle(pic,(cp2[0],cp2[1]),5,(0,0,255),-1)
+                cv2.circle(pic,(cp2[0],cp2[1]),5,point_color(ci),-1)
             pics.append(pic)
             
         pics12 = np.hstack((pics[0],pics[1]))


### PR DESCRIPTION
Fixed the script as discussed.

I also changed `validation.py` slightly, such that multiple points show up in different colors (controlled by the `point_color()` function. The first color is still red, hence it shouldn't interfere with the behavior until now.

The `polygon2cog.py` has now a flag to either only export the COG, or to also export the "closest points" on the rays.